### PR TITLE
rename repository to go-internal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go_import_path: github.com/rogpeppe/modinternal
+go_import_path: github.com/rogpeppe/go-internal
 go: 
   - "1.11"
 script: go test ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
-This repository factors out some internal packages from the cmd/go internal package
-in the Go standard library.
+This repository factors out an opinionated selection of internal packages and functionality from the Go standard
+library. Currently this consists mostly of packages and testing code from within the Go tool implementation.
 
-It also factors out into a separate package the script-based testing functionality
-(http://godoc.org/github.com/rogpeppe/modinternal/testscript) and the Go proxy test server (http://godoc.org/github.com/rogpeppe/modinternal/goproxytest).
+Included are the following:
+
+- dirhash: calculate hashes over directory trees the same way that the Go tool does.
+- goproxytest: a GOPROXY implementation designed for test use.
+- gotooltest: Use the Go tool inside test scripts (see testscript below)
+- imports: list of known architectures and OSs, and support for reading import import statements.
+- modfile: read and write `go.mod` files while preserving formatting and comments.
+- module: module paths and versions.
+- par: do work in parallel.
+- semver: semantic version parsing.
+- testenv: information on the current testing environment.
+- testscript: script-based testing based on txtar files
+- txtar: simple text-based file archives for testing.

--- a/cmd/txtar-addmod/addmod.go
+++ b/cmd/txtar-addmod/addmod.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // The txtar-addmod command adds a module as a txtar archive to the a testdata module directory
-// as understood by the goproxytest package (see https://godoc.org/github.com/rogpeppe/modinternal/goproxytest).
+// as understood by the goproxytest package (see https://godoc.org/github.com/rogpeppe/go-internal/goproxytest).
 //
 // Usage:
 //
@@ -29,7 +29,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/rogpeppe/modinternal/txtar"
+	"github.com/rogpeppe/go-internal/txtar"
 )
 
 func usage() {

--- a/cmd/txtar-goproxy/main.go
+++ b/cmd/txtar-goproxy/main.go
@@ -21,7 +21,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/rogpeppe/modinternal/goproxytest"
+	"github.com/rogpeppe/go-internal/goproxytest"
 )
 
 var proxyAddr = flag.String("addr", "", "run proxy on this network address instead of running any tests")

--- a/cmd/txtar-savedir/savedir.go
+++ b/cmd/txtar-savedir/savedir.go
@@ -8,7 +8,7 @@
 //
 //	txtar-savedir /path/to/dir >saved.txt
 //
-// See https://godoc.org/github.com/rogpeppe/modinternal/txtar for details of the format
+// See https://godoc.org/github.com/rogpeppe/go-internal/txtar for details of the format
 // and how to parse a txtar file.
 //
 package main
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/rogpeppe/modinternal/txtar"
+	"github.com/rogpeppe/go-internal/txtar"
 )
 
 func usage() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/rogpeppe/modinternal
+module github.com/rogpeppe/go-internal
 
 require gopkg.in/errgo.v2 v2.1.0

--- a/goproxytest/proxy.go
+++ b/goproxytest/proxy.go
@@ -37,10 +37,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rogpeppe/modinternal/module"
-	"github.com/rogpeppe/modinternal/par"
-	"github.com/rogpeppe/modinternal/semver"
-	"github.com/rogpeppe/modinternal/txtar"
+	"github.com/rogpeppe/go-internal/module"
+	"github.com/rogpeppe/go-internal/par"
+	"github.com/rogpeppe/go-internal/semver"
+	"github.com/rogpeppe/go-internal/txtar"
 )
 
 var (

--- a/goproxytest/pseudo.go
+++ b/goproxytest/pseudo.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/rogpeppe/modinternal/semver"
+	"github.com/rogpeppe/go-internal/semver"
 )
 
 // This code was taken from cmd/go/internal/modfetch/pseudo.go

--- a/gotooltest/setup.go
+++ b/gotooltest/setup.go
@@ -13,8 +13,8 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/rogpeppe/modinternal/imports"
-	"github.com/rogpeppe/modinternal/testscript"
+	"github.com/rogpeppe/go-internal/imports"
+	"github.com/rogpeppe/go-internal/testscript"
 )
 
 type testContext struct {

--- a/imports/scan_test.go
+++ b/imports/scan_test.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/rogpeppe/modinternal/testenv"
+	"github.com/rogpeppe/go-internal/testenv"
 )
 
 func TestScan(t *testing.T) {

--- a/modfile/rule.go
+++ b/modfile/rule.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/rogpeppe/modinternal/module"
-	"github.com/rogpeppe/modinternal/semver"
+	"github.com/rogpeppe/go-internal/module"
+	"github.com/rogpeppe/go-internal/semver"
 )
 
 // A File is the parsed, interpreted form of a go.mod file.

--- a/module/module.go
+++ b/module/module.go
@@ -24,7 +24,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/rogpeppe/modinternal/semver"
+	"github.com/rogpeppe/go-internal/semver"
 )
 
 // A Version is defined by a module path and version pair.

--- a/testscript/cmd.go
+++ b/testscript/cmd.go
@@ -335,7 +335,7 @@ func scriptMatch(ts *TestScript, neg bool, args []string, text, name string) {
 		want = 2
 	}
 	if len(args) != want {
-		ts.Fatalf("usage: %s [-count=N] 'pattern' file%s", name, extraUsage)
+		ts.Fatalf("usage: %s [-count=N] 'pattern'%s", name, extraUsage)
 	}
 
 	pattern := args[0]

--- a/testscript/doc.go
+++ b/testscript/doc.go
@@ -38,7 +38,7 @@ In general script files should have short names: a few words, not whole sentence
 The first word should be the general category of behavior being tested,
 often the name of a subcommand to be tested or a concept (vendor, pattern).
 
-Each script is a text archive (go doc github.com/rogpeppe/modinternal/txtar).
+Each script is a text archive (go doc github.com/rogpeppe/go-internal/txtar).
 The script begins with an actual command script to run
 followed by the content of zero or more supporting files to
 create in the script's temporary file system before it starts executing.

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rogpeppe/modinternal/par"
-	"github.com/rogpeppe/modinternal/testenv"
-	"github.com/rogpeppe/modinternal/txtar"
+	"github.com/rogpeppe/go-internal/par"
+	"github.com/rogpeppe/go-internal/testenv"
+	"github.com/rogpeppe/go-internal/txtar"
 )
 
 var execCache par.Cache


### PR DESCRIPTION
It's really more than modinternal (e.g. testscript isn't related to modules).