### PR TITLE
goproxytest: avoid import of testing package

### DIFF
--- a/cmd/txtar-goproxy/main.go
+++ b/cmd/txtar-goproxy/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/rogpeppe/go-internal/goproxytest"
 )
 
-var proxyAddr = flag.String("addr", "", "run proxy on this network address instead of running any tests")
+var proxyAddr = flag.String("addr", "", "run proxy on this network address")
 
 func usage() {
 	fmt.Fprintf(os.Stderr, "usage: txtar-goproxy [flags] dir\n")

--- a/goproxytest/proxy.go
+++ b/goproxytest/proxy.go
@@ -26,7 +26,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -35,17 +34,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"testing"
 
 	"github.com/rogpeppe/go-internal/module"
 	"github.com/rogpeppe/go-internal/par"
 	"github.com/rogpeppe/go-internal/semver"
 	"github.com/rogpeppe/go-internal/txtar"
-)
-
-var (
-	proxyAddr = flag.String("proxy", "", "run proxy on this network address instead of running any tests")
-	proxyURL  string
 )
 
 type Server struct {
@@ -283,7 +276,7 @@ func (srv *Server) readArchive(path, vers string) *txtar.Archive {
 	a := srv.archiveCache.Do(name, func() interface{} {
 		a, err := txtar.ParseFile(name)
 		if err != nil {
-			if testing.Verbose() || !os.IsNotExist(err) {
+			if !os.IsNotExist(err) {
 				fmt.Fprintf(os.Stderr, "go proxy: %v\n", err)
 			}
 			a = nil


### PR DESCRIPTION
If we import the testing package, we pollute the txtar-goproxy
command's usage with all the testing flags, which are not
relevant, so avoid doing that. We might need to add
the capability to toggle verbose messages later.