### PR TITLE
testscript: add goversion environment variable to testing script language

### DIFF
--- a/testscript/doc.go
+++ b/testscript/doc.go
@@ -60,6 +60,7 @@ Scripts also have access to these other environment variables:
 	PATH=<actual PATH>
 	TMPDIR=$WORK/tmp
 	devnull=<value of os.DevNull>
+	goversion=<current Go version; for example, 1.12>
 
 The environment variable $exe (lowercase) is an empty string on most
 systems, ".exe" on Windows.

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -12,10 +12,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"go/build"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync/atomic"
@@ -158,6 +160,7 @@ func (ts *TestScript) setup() {
 			homeEnvName() + "=/no-home",
 			tempEnvName() + "=" + filepath.Join(ts.workdir, "tmp"),
 			"devnull=" + os.DevNull,
+			"goversion=" + goVersion(ts),
 			":=" + string(os.PathListSeparator),
 		},
 		WorkDir: ts.workdir,
@@ -175,6 +178,16 @@ func (ts *TestScript) setup() {
 			ts.envMap[kv[:i]] = kv[i+1:]
 		}
 	}
+}
+
+// goVersion returns the current Go version.
+func goVersion(ts *TestScript) string {
+	tags := build.Default.ReleaseTags
+	version := tags[len(tags)-1]
+	if !regexp.MustCompile(`^go([1-9][0-9]*)\.(0|[1-9][0-9]*)$`).MatchString(version) {
+		ts.Fatalf("invalid go version %q", version)
+	}
+	return version[2:]
 }
 
 // run runs the test script.


### PR DESCRIPTION
Originally added in https://go-review.googlesource.com/c/147280