### PR TITLE
testscript: add *TestScript.Setenv method

### DIFF
--- a/testscript/cmd.go
+++ b/testscript/cmd.go
@@ -194,8 +194,7 @@ func (ts *TestScript) cmdEnv(neg bool, args []string) {
 			ts.Logf("%s=%s\n", env, ts.envMap[env])
 			continue
 		}
-		ts.env = append(ts.env, env)
-		ts.envMap[env[:i]] = env[i+1:]
+		ts.Setenv(env[:i], env[i+1:])
 	}
 }
 

--- a/testscript/scripts/setenv.txt
+++ b/testscript/scripts/setenv.txt
@@ -1,0 +1,6 @@
+setSpecialVal
+exists $SPECIALVAL.txt
+ensureSpecialVal
+
+-- 42.txt --
+Douglas Adams

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -495,6 +495,17 @@ func (ts *TestScript) MkAbs(file string) string {
 	return filepath.Join(ts.cd, file)
 }
 
+// Setenv sets the value of the environment variable named by the key.
+func (ts *TestScript) Setenv(key, value string) {
+	ts.env = append(ts.env, key+"="+value)
+	ts.envMap[key] = value
+}
+
+// Getenv gets the value of the environment variable named by the key.
+func (ts *TestScript) Getenv(key string) string {
+	return ts.envMap[key]
+}
+
 // parse parses a single line as a list of space-separated arguments
 // subject to environment variable expansion (but not resplitting).
 // Single quotes around text disable splitting and expansion.

--- a/testscript/testscript_test.go
+++ b/testscript/testscript_test.go
@@ -33,8 +33,23 @@ func TestSimple(t *testing.T) {
 	// TODO set temp directory.
 	Run(t, Params{
 		Dir: "scripts",
+		Cmds: map[string]func(ts *TestScript, neg bool, args []string){
+			"setSpecialVal":    setSpecialVal,
+			"ensureSpecialVal": ensureSpecialVal,
+		},
 	})
 	// TODO check that the temp directory has been removed.
+}
+
+func setSpecialVal(ts *TestScript, neg bool, args []string) {
+	ts.Setenv("SPECIALVAL", "42")
+}
+
+func ensureSpecialVal(ts *TestScript, neg bool, args []string) {
+	want := "42"
+	if got := ts.Getenv("SPECIALVAL"); got != want {
+		ts.Fatalf("expected SPECIALVAL to be %q; got %q", want, got)
+	}
 }
 
 var diffTests = []struct {


### PR DESCRIPTION
Allows environment variables to be set by Run-Param commands.