### PR TITLE
cmd/txtar-addmod: fix bug resolving directory path in module cache.

### DIFF
--- a/cmd/txtar-addmod/addmod.go
+++ b/cmd/txtar-addmod/addmod.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/rogpeppe/go-internal/module"
 	"github.com/rogpeppe/go-internal/txtar"
 )
 
@@ -103,6 +104,14 @@ func main1() int {
 			continue
 		}
 		path, vers, dir := f[0], f[1], f[2]
+
+		encpath, err := module.EncodePath(path)
+		if err != nil {
+			log.Printf("failed to encode path %q: %v", path, err)
+			continue
+		}
+		path = encpath
+
 		mod, err := ioutil.ReadFile(filepath.Join(gopath, "pkg/mod/cache/download", path, "@v", vers+".mod"))
 		if err != nil {
 			log.Printf("%s: %v", arg, err)

--- a/cmd/txtar-addmod/testdata/encode.txt
+++ b/cmd/txtar-addmod/testdata/encode.txt
@@ -1,0 +1,5 @@
+mkdir $WORK/out
+txtar-addmod $WORK/out github.com/shurcooL/httpfs@v0.0.0-20171119174359-809beceb2371
+! stdout .+
+! stderr .+
+exists $WORK/out/github.com_shurcoo!l_httpfs_v0.0.0-20171119174359-809beceb2371.txt

--- a/cmd/txtar-addmod/testdata/mod/github.com_shurcoo!l_httpfs_v0.0.0-20171119174359-809beceb2371.txt
+++ b/cmd/txtar-addmod/testdata/mod/github.com_shurcoo!l_httpfs_v0.0.0-20171119174359-809beceb2371.txt
@@ -1,0 +1,6 @@
+module github.com/shurcooL/httpfs@v0.0.0-20171119174359-809beceb2371
+
+-- .mod --
+module github.com/shurcooL/httpfs
+-- .info --
+{"Version":"v0.0.0-20171119174359-809beceb2371","Time":"2017-11-19T17:43:59Z"}


### PR DESCRIPTION
The URL we fetch with txtar-addmod needs to contain a regular path.
The path on disk however, must be the special ! encoded path.