### PR TITLE
cmd/txtar-addmod: -all flag to include all files

### DIFF
--- a/cmd/txtar-addmod/addmod.go
+++ b/cmd/txtar-addmod/addmod.go
@@ -35,6 +35,7 @@ import (
 
 func usage() {
 	fmt.Fprintf(os.Stderr, "usage: txtar-addmod dir path@version...\n")
+	flag.PrintDefaults()
 	os.Exit(2)
 }
 
@@ -50,6 +51,8 @@ const goCmd = "go"
 func main() {
 	os.Exit(main1())
 }
+
+var allFiles = flag.Bool("all", false, "include all source files")
 
 func main1() int {
 	flag.Usage = usage
@@ -140,14 +143,23 @@ func main1() int {
 			if !info.Mode().IsRegular() {
 				return nil
 			}
+			// TODO: skip dirs like "testdata" or "_foo" unless -all
+			// is given?
 			name := info.Name()
-			if name == "go.mod" || strings.HasSuffix(name, ".go") {
-				data, err := ioutil.ReadFile(path)
-				if err != nil {
-					return err
-				}
-				a.Files = append(a.Files, txtar.File{Name: strings.TrimPrefix(path, dir+string(filepath.Separator)), Data: data})
+			switch {
+			case *allFiles:
+			case name == "go.mod":
+			case strings.HasSuffix(name, ".go"):
+			default:
+				// the name is not in the whitelist, and we're
+				// not including all files via -all
+				return nil
 			}
+			data, err := ioutil.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			a.Files = append(a.Files, txtar.File{Name: strings.TrimPrefix(path, dir+string(filepath.Separator)), Data: data})
 			return nil
 		})
 		if err != nil {

--- a/cmd/txtar-addmod/testdata/mod/github.com_gobin-testrepos_simple-main_v1.0.0.txt
+++ b/cmd/txtar-addmod/testdata/mod/github.com_gobin-testrepos_simple-main_v1.0.0.txt
@@ -14,3 +14,6 @@ import "fmt"
 func main() {
 	fmt.Println("I am a simple module-based main")
 }
+-- foobar --
+This is an extra file that can't be imported with the Go package, but may still
+be used in a test.

--- a/cmd/txtar-addmod/testdata/txtar-addmod-self.txt
+++ b/cmd/txtar-addmod/testdata/txtar-addmod-self.txt
@@ -3,3 +3,7 @@ txtar-addmod $WORK/out github.com/gobin-testrepos/simple-main
 ! stdout .+
 ! stderr .+
 exists $WORK/out/github.com_gobin-testrepos_simple-main_v1.0.0.txt
+! grep foobar $WORK/out/github.com_gobin-testrepos_simple-main_v1.0.0.txt
+
+txtar-addmod -all $WORK/out github.com/gobin-testrepos/simple-main
+grep '-- foobar --' $WORK/out/github.com_gobin-testrepos_simple-main_v1.0.0.txt


### PR DESCRIPTION
This can be useful if certain extra files are needed to pass some tests,
for example.

Added a simple test case too.

Fixes #28.