### PR TITLE
cmd/txtar-x: new command

### DIFF
--- a/cmd/txtar-savedir/savedir.go
+++ b/cmd/txtar-savedir/savedir.go
@@ -31,8 +31,6 @@ func usage() {
 	os.Exit(2)
 }
 
-const goCmd = "go"
-
 func main() {
 	os.Exit(main1())
 }
@@ -44,7 +42,7 @@ func main1() int {
 		usage()
 	}
 
-	log.SetPrefix("savedir: ")
+	log.SetPrefix("txtar-savedir: ")
 	log.SetFlags(0)
 
 	dir := flag.Arg(0)

--- a/cmd/txtar-savedir/script_test.go
+++ b/cmd/txtar-savedir/script_test.go
@@ -14,6 +14,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestScripts(t *testing.T) {
-	p := testscript.Params{Dir: "testdata"}
-	testscript.Run(t, p)
+	testscript.Run(t, testscript.Params{
+		Dir: "testdata",
+	})
 }

--- a/cmd/txtar-x/extract.go
+++ b/cmd/txtar-x/extract.go
@@ -1,0 +1,108 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// The txtar-x command extracts a txtar archive to a filesystem.
+//
+// Usage:
+//
+//	txtar-x [-C root-dir] saved.txt
+//
+// See https://godoc.org/github.com/rogpeppe/go-internal/txtar for details of the format
+// and how to parse a txtar file.
+//
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rogpeppe/go-internal/txtar"
+)
+
+var (
+	extractDir = flag.String("C", ".", "directory to extract files into")
+)
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "usage: txtar-x [flags] [file]\n")
+	flag.PrintDefaults()
+}
+
+func main() {
+	os.Exit(main1())
+}
+
+func main1() int {
+	flag.Usage = usage
+	flag.Parse()
+	if flag.NArg() > 1 {
+		usage()
+		return 2
+	}
+	log.SetPrefix("txtar-x: ")
+	log.SetFlags(0)
+
+	var a *txtar.Archive
+	if flag.NArg() == 0 {
+		data, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			log.Printf("cannot read stdin: %v", err)
+			return 1
+		}
+		a = txtar.Parse(data)
+	} else {
+		a1, err := txtar.ParseFile(flag.Arg(0))
+		if err != nil {
+			log.Print(err)
+			return 1
+		}
+		a = a1
+	}
+	if err := extract(a); err != nil {
+		log.Print(err)
+		return 1
+	}
+	return 0
+}
+
+func extract(a *txtar.Archive) error {
+	for _, f := range a.Files {
+		if err := extractFile(f); err != nil {
+			return fmt.Errorf("cannot extract %q: %v", f.Name, err)
+		}
+	}
+	return nil
+}
+
+func extractFile(f txtar.File) error {
+	path := filepath.Clean(filepath.FromSlash(f.Name))
+	if isAbs(path) || strings.HasPrefix(path, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("outside parent directory")
+	}
+	path = filepath.Join(*extractDir, path)
+	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
+		return err
+	}
+	// Avoid overwriting existing files by using O_EXCL.
+	out, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := out.Write(f.Data); err != nil {
+		return err
+	}
+	return nil
+}
+
+func isAbs(p string) bool {
+	// Note: under Windows, filepath.IsAbs(`\foo`) returns false,
+	// so we need to check for that case specifically.
+	return filepath.IsAbs(p) || strings.HasPrefix(p, string(filepath.Separator))
+}

--- a/cmd/txtar-x/extract_test.go
+++ b/cmd/txtar-x/extract_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/rogpeppe/go-internal/testscript"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testscript.RunMain(m, map[string]func() int{
+		"txtar-x": main1,
+	}))
+}
+
+func TestScripts(t *testing.T) {
+	testscript.Run(t, testscript.Params{
+		Dir: "testdata",
+		Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
+			"unquote": unquote,
+		},
+	})
+}
+
+func unquote(ts *testscript.TestScript, neg bool, args []string) {
+	if neg {
+		ts.Fatalf("unsupported: ! unquote")
+	}
+	for _, arg := range args {
+		file := ts.MkAbs(arg)
+		data, err := ioutil.ReadFile(file)
+		ts.Check(err)
+		data = bytes.Replace(data, []byte("\n>"), []byte("\n"), -1)
+		data = bytes.TrimPrefix(data, []byte(">"))
+		err = ioutil.WriteFile(file, data, 0666)
+		ts.Check(err)
+	}
+}

--- a/cmd/txtar-x/testdata/extract-dir.txt
+++ b/cmd/txtar-x/testdata/extract-dir.txt
@@ -1,0 +1,16 @@
+unquote file.txtar
+txtar-x -C x/y file.txtar
+cmp x/y/foo expect/foo
+cmp x/y/a/b/bar expect/a/b/bar
+
+-- file.txtar --
+>some comment
+>
+>-- foo --
+>foo
+>-- a/b/bar --
+>bar
+-- expect/foo --
+foo
+-- expect/a/b/bar --
+bar

--- a/cmd/txtar-x/testdata/extract-out-of-bounds.txt
+++ b/cmd/txtar-x/testdata/extract-out-of-bounds.txt
@@ -1,0 +1,13 @@
+unquote file1.txtar file2.txtar
+! txtar-x file1.txtar
+stderr 'cannot extract "\.\./foo": outside parent directory'
+
+! txtar-x file2.txtar
+stderr 'cannot extract "/foo": outside parent directory'
+
+-- file1.txtar --
+>-- ../foo --
+>foo
+-- file2.txtar --
+>-- /foo --
+>foo

--- a/cmd/txtar-x/testdata/extract-stdin.txt
+++ b/cmd/txtar-x/testdata/extract-stdin.txt
@@ -1,0 +1,17 @@
+unquote file.txtar
+stdin file.txtar
+txtar-x
+cmp foo expect/foo
+cmp a/b/bar expect/a/b/bar
+
+-- file.txtar --
+>some comment
+>
+>-- foo --
+>foo
+>-- a/b/bar --
+>bar
+-- expect/foo --
+foo
+-- expect/a/b/bar --
+bar

--- a/cmd/txtar-x/testdata/extract.txt
+++ b/cmd/txtar-x/testdata/extract.txt
@@ -1,0 +1,16 @@
+unquote file.txtar
+txtar-x file.txtar
+cmp foo expect/foo
+cmp a/b/bar expect/a/b/bar
+
+-- file.txtar --
+>some comment
+>
+>-- foo --
+>foo
+>-- a/b/bar --
+>bar
+-- expect/foo --
+foo
+-- expect/a/b/bar --
+bar

--- a/testscript/cmd.go
+++ b/testscript/cmd.go
@@ -35,6 +35,7 @@ var scriptCmds = map[string]func(*TestScript, bool, []string){
 	"mkdir":   (*TestScript).cmdMkdir,
 	"rm":      (*TestScript).cmdRm,
 	"skip":    (*TestScript).cmdSkip,
+	"stdin":   (*TestScript).cmdStdin,
 	"stderr":  (*TestScript).cmdStderr,
 	"stdout":  (*TestScript).cmdStdout,
 	"stop":    (*TestScript).cmdStop,
@@ -320,6 +321,18 @@ func (ts *TestScript) cmdSkip(neg bool, args []string) {
 		ts.t.Skip(args[0])
 	}
 	ts.t.Skip()
+}
+
+func (ts *TestScript) cmdStdin(neg bool, args []string) {
+	if neg {
+		ts.Fatalf("unsupported: ! stdin")
+	}
+	if len(args) != 1 {
+		ts.Fatalf("usage: stdin filename")
+	}
+	data, err := ioutil.ReadFile(ts.MkAbs(args[0]))
+	ts.Check(err)
+	ts.stdin = string(data)
 }
 
 // stdout checks that the last go command standard output matches a regexp.

--- a/testscript/doc.go
+++ b/testscript/doc.go
@@ -150,6 +150,9 @@ The predefined commands are:
   test. At the end of the test, any remaining background processes are
   terminated using os.Interrupt (if supported) or os.Kill.
 
+  Standard input can be provided using the stdin command; this will be
+  cleared after exec has been called.
+
 - [!] exists [-readonly] file...
   Each of the listed files or directories must (or must not) exist.
   If -readonly is given, the files or directories must be unwritable.
@@ -166,6 +169,9 @@ The predefined commands are:
 
 - skip [message]
   Mark the test skipped, including the message if given.
+
+- stdin file
+  Set the standard input for the next exec command to the contents of the given file.
 
 - [!] stderr [-count=N] pattern
   Apply the grep command (see above) to the standard error

--- a/testscript/scripts/stdin.txt
+++ b/testscript/scripts/stdin.txt
@@ -1,0 +1,9 @@
+stdin hello.txt
+[exec:cat] exec cat
+stdout hello
+[exec:cat] exec cat
+! stdout hello
+
+-- hello.txt --
+hello
+


### PR DESCRIPTION
This allows the easy extraction of files from a txtar file on the command line.

Also add functionality to testscript to make it possible to set up the standard
input of an execed command.