### PR TITLE
gotooltest: add support for version constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
 go:
   - "1.11.x"
+  - "1.12beta1"
 env:
   - GO111MODULE=on
 go_import_path: github.com/rogpeppe/go-internal

--- a/gotooltest/script_test.go
+++ b/gotooltest/script_test.go
@@ -1,0 +1,22 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gotooltest_test
+
+import (
+	"testing"
+
+	"github.com/rogpeppe/go-internal/gotooltest"
+	"github.com/rogpeppe/go-internal/testscript"
+)
+
+func TestSimple(t *testing.T) {
+	p := testscript.Params{
+		Dir: "testdata",
+	}
+	if err := gotooltest.Setup(&p); err != nil {
+		t.Fatal(err)
+	}
+	testscript.Run(t, p)
+}

--- a/gotooltest/setup.go
+++ b/gotooltest/setup.go
@@ -8,13 +8,19 @@ package gotooltest
 
 import (
 	"fmt"
+	"go/build"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 
 	"github.com/rogpeppe/go-internal/imports"
 	"github.com/rogpeppe/go-internal/testscript"
+)
+
+var (
+	goVersionRegex = regexp.MustCompile(`^go([1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
 )
 
 type testContext struct {
@@ -55,6 +61,14 @@ func Setup(p *testscript.Params) error {
 			if imports.KnownArch[cond] || imports.KnownOS[cond] || cond == "gc" || cond == "gccgo" {
 				return false, nil
 			}
+		}
+		if goVersionRegex.MatchString(cond) {
+			for _, v := range build.Default.ReleaseTags {
+				if cond == v {
+					return true, nil
+				}
+			}
+			return false, nil
 		}
 		if origCondition == nil {
 			return false, fmt.Errorf("unknown condition %q", cond)

--- a/gotooltest/testdata/version.txt
+++ b/gotooltest/testdata/version.txt
@@ -1,0 +1,3 @@
+go version
+[go1.11] [!go1.12] stdout go1\.11
+[go1.12] stdout go1\.12

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -367,8 +367,6 @@ Script:
 // condition reports whether the given condition is satisfied.
 func (ts *TestScript) condition(cond string) (bool, error) {
 	switch cond {
-	case runtime.GOOS, runtime.GOARCH, runtime.Compiler:
-		return true, nil
 	case "short":
 		return testing.Short(), nil
 	case "net":


### PR DESCRIPTION
This effectively mirrors the go/build constraint supports such as go1.12
to check that the Go version is >= 1.12.

Also remove some duplicated code in testscript that I had previously
missed was already present in gotooltest.