### PR TITLE
testscript: provide access to background commands

### DIFF
--- a/gotooltest/setup.go
+++ b/gotooltest/setup.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/rogpeppe/go-internal/imports"
 	"github.com/rogpeppe/go-internal/testscript"
 )
 
@@ -102,13 +101,11 @@ func Setup(p *testscript.Params) error {
 	p.Cmds["go"] = cmdGo
 	origCondition := p.Condition
 	p.Condition = func(cond string) (bool, error) {
-		switch cond {
-		case runtime.GOOS, runtime.GOARCH, runtime.Compiler:
-			return true, nil
-		default:
-			if imports.KnownArch[cond] || imports.KnownOS[cond] || cond == "gc" || cond == "gccgo" {
-				return false, nil
-			}
+		if cond == "gc" || cond == "gccgo" {
+			// TODO this reflects the compiler that the current
+			// binary was built with but not necessarily the compiler
+			// that will be used.
+			return cond == runtime.Compiler, nil
 		}
 		if goVersionRegex.MatchString(cond) {
 			for _, v := range build.Default.ReleaseTags {

--- a/gotooltest/testdata/version.txt
+++ b/gotooltest/testdata/version.txt
@@ -1,3 +1,4 @@
-go version
+go list -f '{{context.ReleaseTags}}' runtime
 [go1.11] [!go1.12] stdout go1\.11
+[go1.11] [!go1.12] ! stdout go1\.12
 [go1.12] stdout go1\.12

--- a/testscript/exe.go
+++ b/testscript/exe.go
@@ -41,6 +41,12 @@ func IgnoreMissedCoverage() {
 // code to pass to os.Exit. It's OK for a command function to
 // exit itself, but this may result in loss of coverage information.
 //
+// When Run is called, these commands will be available as
+// testscript commands; note that these commands behave like
+// commands run with the "exec" command: they set stdout
+// and stderr, and can be run in the background by passing "&"
+// as a final argument.
+//
 // This function returns an exit code to pass to os.Exit, after calling m.Run.
 func RunMain(m TestingM, commands map[string]func() int) (exitCode int) {
 	goCoverProfileMerge()

--- a/testscript/scripts/interrupt.txt
+++ b/testscript/scripts/interrupt.txt
@@ -1,0 +1,7 @@
+[windows] skip
+
+signalcatcher &
+waitfile catchsignal
+interrupt
+wait
+stdout 'caught interrupt'

--- a/testscript/testscript_test.go
+++ b/testscript/testscript_test.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 )
 
 func printArgs() int {
@@ -23,10 +25,26 @@ func exitWithStatus() int {
 	return n
 }
 
+func signalCatcher() int {
+	// Note: won't work under Windows.
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	// Create a file so that the test can know that
+	// we will catch the signal.
+	if err := ioutil.WriteFile("catchsignal", nil, 0666); err != nil {
+		fmt.Println(err)
+		return 1
+	}
+	<-c
+	fmt.Println("caught interrupt")
+	return 0
+}
+
 func TestMain(m *testing.M) {
 	os.Exit(RunMain(m, map[string]func() int{
-		"printargs": printArgs,
-		"status":    exitWithStatus,
+		"printargs":     printArgs,
+		"status":        exitWithStatus,
+		"signalcatcher": signalCatcher,
 	}))
 }
 
@@ -48,13 +66,15 @@ func TestCRLFInput(t *testing.T) {
 	})
 }
 
-func TestSimple(t *testing.T) {
+func TestScripts(t *testing.T) {
 	// TODO set temp directory.
 	Run(t, Params{
 		Dir: "scripts",
 		Cmds: map[string]func(ts *TestScript, neg bool, args []string){
 			"setSpecialVal":    setSpecialVal,
 			"ensureSpecialVal": ensureSpecialVal,
+			"interrupt":        interrupt,
+			"waitfile":         waitFile,
 		},
 	})
 	// TODO check that the temp directory has been removed.
@@ -69,4 +89,41 @@ func ensureSpecialVal(ts *TestScript, neg bool, args []string) {
 	if got := ts.Getenv("SPECIALVAL"); got != want {
 		ts.Fatalf("expected SPECIALVAL to be %q; got %q", want, got)
 	}
+}
+
+// interrupt interrupts the current background command.
+// Note that this will not work under Windows.
+func interrupt(ts *TestScript, neg bool, args []string) {
+	if neg {
+		ts.Fatalf("interrupt does not support neg")
+	}
+	if len(args) > 0 {
+		ts.Fatalf("unexpected args found")
+	}
+	bg := ts.BackgroundCmds()
+	if got, want := len(bg), 1; got != want {
+		ts.Fatalf("unexpected background cmd count; got %d want %d", got, want)
+	}
+	bg[0].Process.Signal(os.Interrupt)
+}
+
+func waitFile(ts *TestScript, neg bool, args []string) {
+	if neg {
+		ts.Fatalf("waitfile does not support neg")
+	}
+	if len(args) != 1 {
+		ts.Fatalf("usage: waitfile file")
+	}
+	path := ts.MkAbs(args[0])
+	for i := 0; i < 100; i++ {
+		_, err := os.Stat(path)
+		if err == nil {
+			return
+		}
+		if !os.IsNotExist(err) {
+			ts.Fatalf("unexpected stat error: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	ts.Fatalf("timed out waiting for %q to be created", path)
 }


### PR DESCRIPTION
This adds a method to TestScript to provide access to the
commands that have been started in the background.
This enables use cases like testing signal handling in
commands.

We also move the OS and architecture conditions to
the base testscript package so that scripts can get
access to OS conditions without importing gotooltest.