### PR TITLE
gotooltest: pass through GOPROXY

### DIFF
--- a/cmd/testscript/testdata/noproxy.txt
+++ b/cmd/testscript/testdata/noproxy.txt
@@ -1,8 +1,10 @@
-# with no .gomodproxy supporting files we should not have a GOPROXY set
+# With no .gomodproxy supporting files, we use the GOPROXY from
+# the environment.
+env GOPROXY=0.1.2.3
 unquote file.txt
 testscript -v file.txt
 
 -- file.txt --
 >go env
->[!windows] stdout '^GOPROXY=""$'
->[windows] stdout '^set GOPROXY=$'
+>[!windows] stdout '^GOPROXY="0.1.2.3"$'
+>[windows] stdout '^set GOPROXY=0.1.2.3$'

--- a/cmd/testscript/testdata/simple.txt
+++ b/cmd/testscript/testdata/simple.txt
@@ -1,3 +1,7 @@
+# With .gomodproxy supporting files, any GOPROXY from the
+# environment should be overridden by the test proxy.
+env GOPROXY=0.1.2.3
+
 unquote file.txt
 testscript -v file.txt
 stdout 'example.com/mod'

--- a/gotooltest/setup.go
+++ b/gotooltest/setup.go
@@ -27,6 +27,7 @@ var (
 	goEnv struct {
 		GOROOT      string
 		GOCACHE     string
+		GOPROXY     string
 		goversion   string
 		releaseTags []string
 		once        sync.Once
@@ -55,9 +56,13 @@ func initGoEnv() error {
 	tagStr = strings.Trim(tagStr, "[]")
 	goEnv.releaseTags = strings.Split(tagStr, " ")
 
-	eout, stderr, err := run("go", "env", "-json", "GOROOT", "GOCACHE")
+	eout, stderr, err := run("go", "env", "-json",
+		"GOROOT",
+		"GOCACHE",
+		"GOPROXY",
+	)
 	if err != nil {
-		return fmt.Errorf("failed to determine GOROOT and GOCACHE tags from go command: %v\n%v", err, stderr)
+		return fmt.Errorf("failed to determine environment from go command: %v\n%v", err, stderr)
 	}
 	if err := json.Unmarshal(eout.Bytes(), &goEnv); err != nil {
 		return fmt.Errorf("failed to unmarshal GOROOT and GOCACHE tags from go command out: %v\n%v", err, eout)
@@ -133,6 +138,7 @@ func goEnviron(env0 []string) []string {
 		"GOOS=" + runtime.GOOS,
 		"GOROOT=" + goEnv.GOROOT,
 		"GOCACHE=" + goEnv.GOCACHE,
+		"GOPROXY=" + goEnv.GOPROXY,
 		"goversion=" + goEnv.goversion,
 	}...)
 }


### PR DESCRIPTION
This can make tests that use the go command
considerably faster. We override GOPROXY when
we're running a local Go test proxy.