### PR TITLE
testscript: let Setup see unarchived txtar files

### DIFF
--- a/testscript/testdata/setupfiles.txt
+++ b/testscript/testdata/setupfiles.txt
@@ -1,0 +1,6 @@
+# check that the Setup function saw the unarchived files,
+# including the temp directory that's always created.
+setup-filenames a b tmp
+
+-- a --
+-- b/c --


### PR DESCRIPTION
This allows a setup step to see the unarchived files
(for example we can use this to start a go module
proxy server in Setup that serves modules from the
testscript contents).