### PR TITLE
testscript: allow "stdout" and "stderr" as inputs to script_test "cp" command

### DIFF
--- a/testscript/cmd.go
+++ b/testscript/cmd.go
@@ -161,16 +161,33 @@ func (ts *TestScript) cmdCp(neg bool, args []string) {
 	}
 
 	for _, arg := range args[:len(args)-1] {
-		src := ts.MkAbs(arg)
-		info, err := os.Stat(src)
-		ts.Check(err)
-		data, err := ioutil.ReadFile(src)
-		ts.Check(err)
+		var (
+			src  string
+			data []byte
+			mode os.FileMode
+		)
+		switch arg {
+		case "stdout":
+			src = arg
+			data = []byte(ts.stdout)
+			mode = 0666
+		case "stderr":
+			src = arg
+			data = []byte(ts.stderr)
+			mode = 0666
+		default:
+			src = ts.MkAbs(arg)
+			info, err := os.Stat(src)
+			ts.Check(err)
+			mode = info.Mode() & 0777
+			data, err = ioutil.ReadFile(src)
+			ts.Check(err)
+		}
 		targ := dst
 		if dstDir {
 			targ = filepath.Join(dst, filepath.Base(src))
 		}
-		ts.Check(ioutil.WriteFile(targ, data, info.Mode()&0777))
+		ts.Check(ioutil.WriteFile(targ, data, mode))
 	}
 }
 

--- a/testscript/doc.go
+++ b/testscript/doc.go
@@ -133,6 +133,8 @@ The predefined commands are:
 
 - cp src... dst
   Copy the listed files to the target file or existing directory.
+  src can include "stdout" or "stderr" to use the standard output or standard error
+  from the most recent exec or go command.
 
 - env [key=value...]
   With no arguments, print the environment (useful for debugging).

--- a/testscript/testdata/cpstdout.txt
+++ b/testscript/testdata/cpstdout.txt
@@ -1,0 +1,10 @@
+[!exec:cat] stop
+
+# hello world
+exec cat hello.text
+cp stdout got
+cmp got hello.text
+
+-- hello.text --
+hello world
+


### PR DESCRIPTION
Cherry picked from https://go-review.googlesource.com/c/163519