### PR TITLE
testscript: add unquote command

### DIFF
--- a/cmd/testscript/main_test.go
+++ b/cmd/testscript/main_test.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -52,7 +51,6 @@ func TestScripts(t *testing.T) {
 			return nil
 		},
 		Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
-			"unquote":        unquote,
 			"dropgofrompath": dropgofrompath,
 			"setfilegoproxy": setfilegoproxy,
 		},
@@ -61,21 +59,6 @@ func TestScripts(t *testing.T) {
 		t.Fatal(err)
 	}
 	testscript.Run(t, p)
-}
-
-func unquote(ts *testscript.TestScript, neg bool, args []string) {
-	if neg {
-		ts.Fatalf("unsupported: ! unquote")
-	}
-	for _, arg := range args {
-		file := ts.MkAbs(arg)
-		data, err := ioutil.ReadFile(file)
-		ts.Check(err)
-		data = bytes.Replace(data, []byte("\n>"), []byte("\n"), -1)
-		data = bytes.TrimPrefix(data, []byte(">"))
-		err = ioutil.WriteFile(file, data, 0666)
-		ts.Check(err)
-	}
 }
 
 func dropgofrompath(ts *testscript.TestScript, neg bool, args []string) {

--- a/cmd/txtar-savedir/testdata/needquote.txt
+++ b/cmd/txtar-savedir/testdata/needquote.txt
@@ -1,0 +1,14 @@
+unquote blah/withsep
+unquote expect
+txtar-savedir blah
+stderr 'txtar-savedir: blah.withsep: ignoring file with txtar marker in'
+cmp stdout expect
+
+-- blah/withsep --
+>-- separator --
+>foo
+-- blah/nosep --
+bar
+-- expect --
+>-- nosep --
+>bar

--- a/cmd/txtar-savedir/testdata/quote.txt
+++ b/cmd/txtar-savedir/testdata/quote.txt
@@ -1,0 +1,14 @@
+unquote blah/withsep
+unquote expect
+txtar-savedir -quote blah
+! stderr .+
+cmp stdout expect
+
+-- blah/withsep --
+>-- separator --
+>foo
+-- expect --
+>unquote withsep
+>-- withsep --
+>>-- separator --
+>>foo

--- a/cmd/txtar-savedir/testdata/txtar-savedir-self.txt
+++ b/cmd/txtar-savedir/testdata/txtar-savedir-self.txt
@@ -2,9 +2,10 @@
 # define a txtar archive-generated file that is the golden output from txtar-savedir
 # So we can't actually test the output for now, instead we just rely on a simple
 # stdout check
+unquote expect
 txtar-savedir blah
 ! stderr .+
-stdout '^module example.com/blah$'
+cmp stdout expect
 
 -- blah/go.mod --
 module example.com/blah
@@ -17,3 +18,15 @@ import "fmt"
 func main() {
   fmt.Println("Hello, world!")
 }
+-- expect --
+>-- go.mod --
+>module example.com/blah
+>
+>-- main.go --
+>package main
+>
+>import "fmt"
+>
+>func main() {
+>  fmt.Println("Hello, world!")
+>}

--- a/testscript/cmd.go
+++ b/testscript/cmd.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/rogpeppe/go-internal/internal/textutil"
+	"github.com/rogpeppe/go-internal/txtar"
 )
 
 // scriptCmds are the script command implementations.
@@ -34,6 +35,7 @@ var scriptCmds = map[string]func(*TestScript, bool, []string){
 	"grep":    (*TestScript).cmdGrep,
 	"mkdir":   (*TestScript).cmdMkdir,
 	"rm":      (*TestScript).cmdRm,
+	"unquote": (*TestScript).cmdUnquote,
 	"skip":    (*TestScript).cmdSkip,
 	"stdin":   (*TestScript).cmdStdin,
 	"stderr":  (*TestScript).cmdStderr,
@@ -300,6 +302,22 @@ func (ts *TestScript) cmdMkdir(neg bool, args []string) {
 	}
 	for _, arg := range args {
 		ts.Check(os.MkdirAll(ts.MkAbs(arg), 0777))
+	}
+}
+
+// unquote unquotes files.
+func (ts *TestScript) cmdUnquote(neg bool, args []string) {
+	if neg {
+		ts.Fatalf("unsupported: ! unquote")
+	}
+	for _, arg := range args {
+		file := ts.MkAbs(arg)
+		data, err := ioutil.ReadFile(file)
+		ts.Check(err)
+		data, err = txtar.Unquote(data)
+		ts.Check(err)
+		err = ioutil.WriteFile(file, data, 0666)
+		ts.Check(err)
 	}
 }
 

--- a/testscript/doc.go
+++ b/testscript/doc.go
@@ -166,6 +166,12 @@ The predefined commands are:
 - mkdir path...
   Create the listed directories, if they do not already exists.
 
+- unquote file...
+  Rewrite each file by replacing any leading ">" characters from
+  each line. This enables a file to contain substrings that look like
+  txtar file markers.
+  See also https://godoc.org/github.com/rogpeppe/go-internal/txtar#Unquote
+
 - rm file...
   Remove the listed files or directories.
 


### PR DESCRIPTION
We add an unquote command to the standard set of commands,
because it's not that uncommon a requirement.

We add a `-quote` flag to txtar-savedir that will automatically
quote files if needed, adding an unquote command to the
comment section.

Future work could add a way of quoting arbitrary data (e.g. binary
data) but this should do for now.

Fixes #11.