### PR TITLE
cmd/txtar-savedir: add -a flag and rename to txtar-c

### DIFF
--- a/cmd/txtar-c/script_test.go
+++ b/cmd/txtar-c/script_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestMain(m *testing.M) {
 	os.Exit(testscript.RunMain(m, map[string]func() int{
-		"txtar-savedir": main1,
+		"txtar-c": main1,
 	}))
 }
 

--- a/cmd/txtar-c/testdata/all.txt
+++ b/cmd/txtar-c/testdata/all.txt
@@ -1,0 +1,56 @@
+unquote expect-all
+unquote expect-no-all
+
+# Without the -a flag, it should ignore . files.
+txtar-c blah
+! stderr .+
+cmp stdout expect-no-all
+
+# With the -a flag, it should include them.
+txtar-c -a blah
+! stderr .+
+cmp stdout expect-all
+
+-- blah/.foo/foo --
+foo
+-- blah/.other --
+other
+-- blah/go.mod --
+module example.com/blah
+
+-- blah/main.go --
+package main
+
+import "fmt"
+
+func main() {
+  fmt.Println("Hello, world!")
+}
+-- expect-all --
+>-- .foo/foo --
+>foo
+>-- .other --
+>other
+>-- go.mod --
+>module example.com/blah
+>
+>-- main.go --
+>package main
+>
+>import "fmt"
+>
+>func main() {
+>  fmt.Println("Hello, world!")
+>}
+-- expect-no-all --
+>-- go.mod --
+>module example.com/blah
+>
+>-- main.go --
+>package main
+>
+>import "fmt"
+>
+>func main() {
+>  fmt.Println("Hello, world!")
+>}

--- a/cmd/txtar-c/testdata/needquote.txt
+++ b/cmd/txtar-c/testdata/needquote.txt
@@ -1,7 +1,7 @@
 unquote blah/withsep
 unquote expect
-txtar-savedir blah
-stderr 'txtar-savedir: blah.withsep: ignoring file with txtar marker in'
+txtar-c blah
+stderr 'txtar-c: blah.withsep: ignoring file with txtar marker in'
 cmp stdout expect
 
 -- blah/withsep --

--- a/cmd/txtar-c/testdata/quote.txt
+++ b/cmd/txtar-c/testdata/quote.txt
@@ -1,6 +1,6 @@
 unquote blah/withsep
 unquote expect
-txtar-savedir -quote blah
+txtar-c -quote blah
 ! stderr .+
 cmp stdout expect
 

--- a/cmd/txtar-c/testdata/txtar-savedir-self.txt
+++ b/cmd/txtar-c/testdata/txtar-savedir-self.txt
@@ -1,9 +1,5 @@
-# Because of https://github.com/rogpeppe/go-internal/issues/11 we cannot
-# define a txtar archive-generated file that is the golden output from txtar-savedir
-# So we can't actually test the output for now, instead we just rely on a simple
-# stdout check
 unquote expect
-txtar-savedir blah
+txtar-c blah
 ! stderr .+
 cmp stdout expect
 
@@ -18,6 +14,8 @@ import "fmt"
 func main() {
   fmt.Println("Hello, world!")
 }
+-- blah/subdir/x --
+x contents
 -- expect --
 >-- go.mod --
 >module example.com/blah
@@ -30,3 +28,5 @@ func main() {
 >func main() {
 >  fmt.Println("Hello, world!")
 >}
+>-- subdir/x --
+>x contents

--- a/goproxytest/proxy.go
+++ b/goproxytest/proxy.go
@@ -16,7 +16,7 @@ content of the module zip file.  The path@vers prefix required of files in the
 zip file is added automatically by the proxy: the files in the archive have
 names without the prefix, like plain "go.mod", "x.go", and so on.
 
-See ../cmd/txtar-addmod and ../cmd/txtar-savedir for tools generate txtar
+See ../cmd/txtar-addmod and ../cmd/txtar-c for tools generate txtar
 files, although it's fine to write them by hand.
 */
 package goproxytest


### PR DESCRIPTION
I could never remember the txtar-savedir name and `txtar-c` seems more
reminiscent of the `tar` original.

Also it's sometimes useful to be able to create txtar files containing
dot files (particularly `.gomodproxy` directories) so allow that too.