### PR TITLE
testscript: provide way for Setup to pass values to commands

### DIFF
--- a/testscript/testdata/exec_path_change.txt
+++ b/testscript/testdata/exec_path_change.txt
@@ -15,6 +15,9 @@ exec go$exe build
 exec go$exe version
 stdout 'This is not go'
 
+-- go/go.mod --
+module example.com/go
+
 -- go/main.go --
 package main
 

--- a/testscript/testdata/values.txt
+++ b/testscript/testdata/values.txt
@@ -1,0 +1,1 @@
+test-values

--- a/testscript/testscript_test.go
+++ b/testscript/testscript_test.go
@@ -93,6 +93,11 @@ func TestScripts(t *testing.T) {
 					ts.Fatalf("setup did not see expected files; got %q want %q", setupFilenames, args)
 				}
 			},
+			"test-values": func(ts *TestScript, neg bool, args []string) {
+				if ts.Value("somekey") != 1234 {
+					ts.Fatalf("test-values did not see expected value")
+				}
+			},
 		},
 		Setup: func(env *Env) error {
 			infos, err := ioutil.ReadDir(env.WorkDir)
@@ -103,6 +108,7 @@ func TestScripts(t *testing.T) {
 			for _, info := range infos {
 				setupFilenames = append(setupFilenames, info.Name())
 			}
+			env.Values["somekey"] = 1234
 			return nil
 		},
 	})


### PR DESCRIPTION
Currently, if Setup sets up something, there's no way for it
to pass values through to custom commands other than
strings (with Setenv). To allow this, we add a map of
arbitrary values to Env that can be accessed by custom commands.
Like context.Context, the keys are `interface{}` values to
allow external helper libraries to add their own keys without
fear of clashing with others.