### PR TITLE
lockedfile: add Append function

### DIFF
--- a/lockedfile/lockedfile.go
+++ b/lockedfile/lockedfile.go
@@ -120,3 +120,19 @@ func Write(name string, content io.Reader, perm os.FileMode) (err error) {
 	}
 	return err
 }
+
+// Append opens the named file (creating it with the given permissions if needed),
+// then write-locks it and appends it with the given content.
+func Append(name string, content io.Reader, perm os.FileMode) (err error) {
+	f, err := OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_APPEND, perm)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(f, content)
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	return err
+}
+


### PR DESCRIPTION
This commit adds Append function to cmd/go/internal/lockedfile.
It has the same behaviour as Write, except that it doesn't truncate the file if it already exists.

Refer to: https://github.com/golang/go/pull/30211 (or https://go-review.googlesource.com/c/go/+/162437)