### PR TITLE
ci: changes for go1.13beta1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
 language: go
+
 os:
   - windows
   - linux
   - osx
+
+branches:
+  only:
+    - master
+
 go:
   - "1.11.x"
   - "1.12.x"
+  - "1.13beta1"
+
 env:
   - GO111MODULE=on
+
 go_import_path: github.com/rogpeppe/go-internal
 
 # Add this before_install until we have a definitive resolution on

--- a/cmd/testscript/main.go
+++ b/cmd/testscript/main.go
@@ -221,7 +221,10 @@ func run(runDir, fileName string, verbose bool, envVars []string) error {
 		addSetup(func(env *testscript.Env) error {
 			// Add GOPROXY after calling the original setup
 			// so that it overrides any GOPROXY set there.
-			env.Vars = append(env.Vars, "GOPROXY="+srv.URL)
+			env.Vars = append(env.Vars,
+				"GOPROXY="+srv.URL,
+				"GONOSUMDB=*",
+			)
 			return nil
 		})
 	}

--- a/cmd/testscript/main_test.go
+++ b/cmd/testscript/main_test.go
@@ -47,6 +47,7 @@ func TestScripts(t *testing.T) {
 		Setup: func(env *testscript.Env) error {
 			env.Vars = append(env.Vars,
 				"GOINTERNALMODPATH="+filepath.Dir(gomod),
+				"GONOSUMDB=*",
 			)
 			return nil
 		},

--- a/cmd/testscript/testdata/env_var_with_go.txt
+++ b/cmd/testscript/testdata/env_var_with_go.txt
@@ -13,7 +13,8 @@ unquote withproxy.txt
 testscript -v noproxy.txt
 stdout ^BANANA=$
 stdout '^GOPATH=\$WORK[/\\]gopath'$
-stdout ^GOPROXY=$
+[!go1.13] stdout ^GOPROXY=$
+[go1.13] stdout ^GOPROXY=https://proxy.golang.org,direct$
 ! stderr .+
 
 env BANANA=banana
@@ -25,7 +26,8 @@ env GOPROXY=
 testscript -v noproxy.txt
 stdout ^BANANA=$
 stdout '^GOPATH=\$WORK[/\\]gopath'$
-stdout ^GOPROXY=$
+[!go1.13] stdout ^GOPROXY=$
+[go1.13] stdout ^GOPROXY=https://proxy.golang.org,direct$
 ! stderr .+
 
 # no GOPROXY, no pass-through, with proxy

--- a/cmd/txtar-addmod/script_test.go
+++ b/cmd/txtar-addmod/script_test.go
@@ -42,7 +42,10 @@ func TestScripts(t *testing.T) {
 	p := testscript.Params{
 		Dir: "testdata",
 		Setup: func(e *testscript.Env) error {
-			e.Vars = append(e.Vars, "GOPROXY="+proxyURL)
+			e.Vars = append(e.Vars,
+				"GOPROXY="+proxyURL,
+				"GONOSUMDB=*",
+			)
 			return nil
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/rogpeppe/go-internal
 
+go 1.11
+
 require gopkg.in/errgo.v2 v2.1.0

--- a/goproxytest/proxy.go
+++ b/goproxytest/proxy.go
@@ -193,8 +193,13 @@ func (srv *Server) handler(w http.ResponseWriter, r *http.Request) {
 
 	a := srv.readArchive(path, vers)
 	if a == nil {
+		// As of https://go-review.googlesource.com/c/go/+/189517, cmd/go
+		// resolves all paths. i.e. for github.com/hello/world, cmd/go attempts
+		// to resolve github.com, github.com/hello and github.com/hello/world.
+		// cmd/go expects a 404/410 response if there is nothing there. Hence we
+		// cannot return with a 500.
 		fmt.Fprintf(os.Stderr, "go proxy: no archive %s %s\n", path, vers)
-		http.Error(w, "cannot load archive", 500)
+		http.NotFound(w, r)
 		return
 	}
 

--- a/goproxytest/proxy_test.go
+++ b/goproxytest/proxy_test.go
@@ -23,6 +23,7 @@ func TestScripts(t *testing.T) {
 		Setup: func(e *testscript.Env) error {
 			e.Vars = append(e.Vars,
 				"GOPROXY="+srv.URL,
+				"GONOSUMDB=*",
 			)
 			return nil
 		},

--- a/goproxytest/testdata/list.txt
+++ b/goproxytest/testdata/list.txt
@@ -4,8 +4,8 @@
 go list -m -versions fruit.com
 stdout 'v1.0.0 v1.1.0'
 
-go get -m fruit.com@v1.0.0
-go get -m fruit.com@v1.1.0
+go get -d fruit.com@v1.0.0
+go get -d fruit.com@v1.1.0
 
 -- go.mod --
 module mod

--- a/testscript/testscript_test.go
+++ b/testscript/testscript_test.go
@@ -109,6 +109,9 @@ func TestScripts(t *testing.T) {
 				setupFilenames = append(setupFilenames, info.Name())
 			}
 			env.Values["somekey"] = 1234
+			env.Vars = append(env.Vars,
+				"GONOSUMDB=*",
+			)
 			return nil
 		},
 	})


### PR DESCRIPTION
Also:

* make explicit the entire Go version matrix
* make goproxytest honour the 404 behaviour expected by cmd/go in tip as
a result of https://go-review.googlesource.com/c/go/+/189517