### PR TITLE
testscript: ensure that temp dir isn't a symlink

### DIFF
--- a/testscript/testdata/evalsymlink.txt
+++ b/testscript/testdata/evalsymlink.txt
@@ -1,0 +1,8 @@
+# If ioutil.TempDir returns a sym linked dir (default behaviour in macOS for example) the
+# matcher will have problems with external programs that uses the real path.
+# This script tests that $WORK is matched in a consistent way (also see #79).
+[windows] skip
+exec pwd
+stdout ^$WORK$
+exec pwd -P
+stdout ^$WORK$

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -150,6 +150,14 @@ func RunT(t T, p Params) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// The temp dir returned by ioutil.TempDir might be a sym linked dir (default
+	// behaviour in macOS). That could mess up matching that includes $WORK if,
+	// for example, an external program outputs resolved paths. Evaluating the
+	// dir here will ensure consistency.
+	testTempDir, err = filepath.EvalSymlinks(testTempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	refCount := int32(len(files))
 	for _, file := range files {
 		file := file


### PR DESCRIPTION
I ran into issues in `govim` with the testscript matcher since it uses real paths in the logs. When running macOS `ioutil.TempDir()` returns a sym-linked directory by default.

This PR ensures that the path used is a real directory by evaluating the root test temp dir that acts as base for `$WORK`.

See full description in https://github.com/myitcv/govim/issues/308