### PR TITLE
change 1.13beta1 to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ branches:
 go:
   - "1.11.x"
   - "1.12.x"
-  - "1.13beta1"
+  - "1.13"
 
 env:
   - GO111MODULE=on


### PR DESCRIPTION
PR sets the Go version to `1.13` since it is released now.