### PR TITLE
testscript: add ReadFile method

### DIFF
--- a/testscript/cmd.go
+++ b/testscript/cmd.go
@@ -119,21 +119,11 @@ func (ts *TestScript) cmdCmpenv(neg bool, args []string) {
 
 func (ts *TestScript) doCmdCmp(args []string, env bool) {
 	name1, name2 := args[0], args[1]
-	var text1, text2 string
-	if name1 == "stdout" {
-		text1 = ts.stdout
-	} else if name1 == "stderr" {
-		text1 = ts.stderr
-	} else {
-		data, err := ioutil.ReadFile(ts.MkAbs(name1))
-		ts.Check(err)
-		text1 = string(data)
-	}
+	text1 := ts.ReadFile(name1)
 
 	data, err := ioutil.ReadFile(ts.MkAbs(name2))
 	ts.Check(err)
-	text2 = string(data)
-
+	text2 := string(data)
 	if env {
 		text2 = ts.expand(text2)
 	}

--- a/testscript/testdata/readfile.txt
+++ b/testscript/testdata/readfile.txt
@@ -1,0 +1,10 @@
+echo stdout stdout
+testreadfile stdout
+
+echo stderr stderr
+testreadfile stderr
+
+testreadfile x/somefile
+
+-- x/somefile --
+x/somefile

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -631,6 +631,27 @@ func (ts *TestScript) MkAbs(file string) string {
 	return filepath.Join(ts.cd, file)
 }
 
+// ReadFile returns the contents of the file with the
+// given name, intepreted relative to the test script's
+// current directory. It interprets "stdout" and "stderr" to
+// mean the standard output or standard error from
+// the most recent exec or wait command respectively.
+//
+// If the file cannot be read, the script fails.
+func (ts *TestScript) ReadFile(file string) string {
+	switch file {
+	case "stdout":
+		return ts.stdout
+	case "stderr":
+		return ts.stderr
+	default:
+		file = ts.MkAbs(file)
+		data, err := ioutil.ReadFile(file)
+		ts.Check(err)
+		return string(data)
+	}
+}
+
 // Setenv sets the value of the environment variable named by the key.
 func (ts *TestScript) Setenv(key, value string) {
 	ts.env = append(ts.env, key+"="+value)


### PR DESCRIPTION
This allows custom commands to operate on the output of previous
exec commands similar to the built in cp and cmp commands.