### PR TITLE
testscript: fail a test when a testscript Dir contains no scripts

### DIFF
--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -152,9 +152,13 @@ func (t tshim) Verbose() bool {
 // RunT is like Run but uses an interface type instead of the concrete *testing.T
 // type to make it possible to use testscript functionality outside of go test.
 func RunT(t T, p Params) {
-	files, err := filepath.Glob(filepath.Join(p.Dir, "*.txt"))
+	glob := filepath.Join(p.Dir, "*.txt")
+	files, err := filepath.Glob(glob)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal(fmt.Sprintf("no scripts found matching glob: %v", glob))
 	}
 	testTempDir, err := ioutil.TempDir(os.Getenv("GOTMPDIR"), "go-test-script")
 	if err != nil {

--- a/testscript/testscript_test.go
+++ b/testscript/testscript_test.go
@@ -202,6 +202,32 @@ func TestTestwork(t *testing.T) {
 	}
 }
 
+// TestBadDir verifies that invoking testscript with a directory that either
+// does not exist or that contains no *.txt scripts fails the test
+func TestBadDir(t *testing.T) {
+	ft := new(fakeT)
+	func() {
+		defer func() {
+			if err := recover(); err != nil {
+				if err != errAbort {
+					panic(err)
+				}
+			}
+		}()
+		RunT(ft, Params{
+			Dir: "thiswillnevermatch",
+		})
+	}()
+	wantCount := 1
+	if got := len(ft.failMsgs); got != wantCount {
+		t.Fatalf("expected %v fail message; got %v", wantCount, got)
+	}
+	wantMsg := regexp.MustCompile(`no scripts found matching glob: thiswillnevermatch[/\\]\*\.txt`)
+	if got := ft.failMsgs[0]; !wantMsg.MatchString(got) {
+		t.Fatalf("expected msg to match `%v`; got:\n%v", wantMsg, got)
+	}
+}
+
 func setSpecialVal(ts *TestScript, neg bool, args []string) {
 	ts.Setenv("SPECIALVAL", "42")
 }


### PR DESCRIPTION
This can happen when either the Dir does not exist, or it is empty.