### PR TITLE
testscript: add ${/} as a companion to ${:}

### DIFF
--- a/testscript/testdata/exec_path_change.txt
+++ b/testscript/testdata/exec_path_change.txt
@@ -1,17 +1,17 @@
 # If the PATH environment variable is set in the testscript.Params.Setup phase
 # or set directly within a script, exec should honour that PATH
 
-[!windows] env HOME=$WORK/home
-[windows]  env HOME=$WORK\home
-[windows]  env USERPROFILE=$WORK\home
-[windows]  env LOCALAPPDATA=$WORK\appdata
+[!exec:go] skip
+
+env HOME=$WORK${/}home
+[windows] env USERPROFILE=$WORK\home
+[windows] env LOCALAPPDATA=$WORK\appdata
 
 cd go
 exec go$exe version
 stdout 'go version'
 exec go$exe build
-[!windows] env PATH=$WORK/go${:}$PATH
-[windows]  env PATH=$WORK\go${:}$PATH
+env PATH=$WORK${/}go${:}$PATH
 exec go$exe version
 stdout 'This is not go'
 

--- a/testscript/testdata/stdin.txt
+++ b/testscript/testdata/stdin.txt
@@ -1,7 +1,9 @@
+[!exec:cat] skip
+
 stdin hello.txt
-[exec:cat] exec cat
+exec cat
 stdout hello
-[exec:cat] exec cat
+exec cat
 ! stdout hello
 
 -- hello.txt --

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -264,6 +264,7 @@ func (ts *TestScript) setup() string {
 			homeEnvName() + "=/no-home",
 			tempEnvName() + "=" + filepath.Join(ts.workdir, "tmp"),
 			"devnull=" + os.DevNull,
+			"/=" + string(os.PathSeparator),
 			":=" + string(os.PathListSeparator),
 		},
 		WorkDir: ts.workdir,


### PR DESCRIPTION
${:} expands to os.PathListSeparator; now ${/} expands to
os.PathSeparator.

It's useful to skip windows-vs-unixy conditions, like the ones that we
simplified in exec_path_change with HOME and PATH.

It's also useful so that 'cmpenv stdout stdout.golden' can easily
support output which contains relative file paths.

While at it, make the stdin and exec_path_change scripts work on Wine
(i.e. vanilla Windows), which has neither Go nor coreutils installed.