### PR TITLE
testscript: support stdout/stderr in more builtins

### DIFF
--- a/testscript/cmd.go
+++ b/testscript/cmd.go
@@ -363,9 +363,7 @@ func (ts *TestScript) cmdStdin(neg bool, args []string) {
 	if len(args) != 1 {
 		ts.Fatalf("usage: stdin filename")
 	}
-	data, err := ioutil.ReadFile(ts.MkAbs(args[0]))
-	ts.Check(err)
-	ts.stdin = string(data)
+	ts.stdin = ts.ReadFile(args[0])
 }
 
 // stdout checks that the last go command standard output matches a regexp.

--- a/testscript/doc.go
+++ b/testscript/doc.go
@@ -180,6 +180,8 @@ The predefined commands are:
 
 - stdin file
   Set the standard input for the next exec command to the contents of the given file.
+  File can be "stdout" or "stderr" to use the standard output or standard error
+  from the most recent exec or wait command.
 
 - [!] stderr [-count=N] pattern
   Apply the grep command (see above) to the standard error

--- a/testscript/testdata/stdin.txt
+++ b/testscript/testdata/stdin.txt
@@ -4,6 +4,15 @@ stdout hello
 [exec:cat] exec cat
 ! stdout hello
 
+
+[!exec:cat] stop
+
+# Check that 'stdin stdout' works.
+exec cat hello.txt
+stdin stdout
+exec cat
+stdout hello
+
 -- hello.txt --
 hello
 


### PR DESCRIPTION
Support these special files in the stdin, unquote, and match (grep)
commands. This is particularly useful to "pipe" output like "stdin
stdout", or to use commands that produce txtar output.

The grep one isn't super useful, as one can already do "stdout xxx"
instead of "grep xxx stdout", but this way it's more consistent and we
save some repeated lines. Because the feature is itself a bit redundant,
don't document it, to prevent confusing the user.