### PR TITLE
testscript: expose current subtest in Env

### DIFF
--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -69,6 +69,18 @@ func (e *Env) Defer(f func()) {
 	e.ts.Defer(f)
 }
 
+// T returns the t argument passed to the current test by the T.Run method.
+// Note that if the tests were started by calling Run,
+// the returned value will implement testing.TB.
+// Note that, despite that, the underlying value will not be of type
+// *testing.T because *testing.T does not implement T.
+//
+// If Cleanup is called on the returned value, the function will run
+// after any functions passed to Env.Defer.
+func (e *Env) T() T {
+	return e.ts.t
+}
+
 // Params holds parameters for a call to Run.
 type Params struct {
 	// Dir holds the name of the directory holding the scripts.

--- a/testscript/testscript_test.go
+++ b/testscript/testscript_test.go
@@ -113,6 +113,12 @@ func TestScripts(t *testing.T) {
 				if ts.Value("somekey") != 1234 {
 					ts.Fatalf("test-values did not see expected value")
 				}
+				if ts.Value("t").(T) != ts.t {
+					ts.Fatalf("test-values did not see expected t")
+				}
+				if _, ok := ts.Value("t").(testing.TB); !ok {
+					ts.Fatalf("test-values t does not implement testing.TB")
+				}
 			},
 			"testreadfile": func(ts *TestScript, neg bool, args []string) {
 				if len(args) != 1 {
@@ -165,6 +171,7 @@ func TestScripts(t *testing.T) {
 			}
 			env.Values["setupFilenames"] = setupFilenames
 			env.Values["somekey"] = 1234
+			env.Values["t"] = env.T()
 			env.Vars = append(env.Vars,
 				"GONOSUMDB=*",
 			)


### PR DESCRIPTION
This way, the setup function could fail in case setting up the test is currently not possible.
Moreover, client code could type assert the returned testscript.T at its own risk, for instance for registering cleanup functions or using test helpers like
```go
tb := env.T().(testing.TB)
c := qt.New(tb)
env.Defer(c.Done)
```