### PR TITLE
testscript: update chmod from golang/go

### DIFF
--- a/testscript/cmd.go
+++ b/testscript/cmd.go
@@ -71,25 +71,23 @@ func (ts *TestScript) cmdCd(neg bool, args []string) {
 }
 
 func (ts *TestScript) cmdChmod(neg bool, args []string) {
-	if len(args) != 2 {
-		ts.Fatalf("usage: chmod mode file")
-	}
-	mode, err := strconv.ParseInt(args[0], 8, 32)
-	if err != nil {
-		ts.Fatalf("bad file mode %q: %v", args[0], err)
-	}
-	if mode > 0777 {
-		ts.Fatalf("unsupported file mode %.3o", mode)
-	}
-	err = os.Chmod(ts.MkAbs(args[1]), os.FileMode(mode))
 	if neg {
-		if err == nil {
-			ts.Fatalf("unexpected chmod success")
-		}
-		return
+		ts.Fatalf("unsupported: ! chmod")
 	}
-	if err != nil {
-		ts.Fatalf("unexpected chmod failure: %v", err)
+	if len(args) != 2 {
+		ts.Fatalf("usage: chmod perm paths...")
+	}
+	perm, err := strconv.ParseUint(args[0], 8, 32)
+	if err != nil || perm&uint64(os.ModePerm) != perm {
+		ts.Fatalf("invalid mode: %s", args[0])
+	}
+	for _, arg := range args[1:] {
+		path := arg
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(ts.cd, arg)
+		}
+		err := os.Chmod(path, os.FileMode(perm))
+		ts.Check(err)
 	}
 }
 

--- a/testscript/doc.go
+++ b/testscript/doc.go
@@ -116,9 +116,9 @@ The predefined commands are:
 - cd dir
   Change to the given directory for future commands.
 
-- chmod mode file
-
-  Change the permissions of file or directory to the given octal mode (000 to 777).
+- chmod perm path...
+  Change the permissions of the files or directories named by the path arguments
+  to the given octal mode (000 to 777).
 
 - cmp file1 file2
   Check that the named files have the same content.


### PR DESCRIPTION
This pulls in the latest changes to `chmod` from upstream, as [requested by @myitcv](https://github.com/rogpeppe/go-internal/pull/102#issuecomment-629023974).

Note that this change breaks backwards compatibility. Upstream parses the permission as a regular integer, whereas testscript parses it as an octal integer, meaning that you need update your scripts to prefix permissions with a `0`.

Replaces #102.