### PR TITLE
testscript: add -text argument to cmp and cmpenv

### DIFF
--- a/testscript/doc.go
+++ b/testscript/doc.go
@@ -120,14 +120,15 @@ The predefined commands are:
   Change the permissions of the files or directories named by the path arguments
   to the given octal mode (000 to 777).
 
-- cmp file1 file2
+- cmp [-text] file1 file2
   Check that the named files have the same content.
+  If -text is given then ignore line ending differences and any trailing newline.
   By convention, file1 is the actual data and file2 the expected data.
   File1 can be "stdout" or "stderr" to use the standard output or standard error
   from the most recent exec or wait command.
   (If the files have differing content, the failure prints a diff.)
 
-- cmpenv file1 file2
+- cmpenv [-text] file1 file2
   Like cmp, but environment variables in file2 are substituted before the
   comparison. For example, $GOOS is replaced by the target GOOS.
 


### PR DESCRIPTION
This PR adds a `-text` flag to testscript's builtin `cmp` and `cmpenv` commands which helps when writing cross-platform testscripts by ignoring line ending differences.

As everybody painfully knows, Windows uses different line endings to the rest of the world, which can creep in in many places:
* Depending on the user's git `core.autocrlf` setting, they may or may not appear in the txtar section of the testscript when the user checks out the testscript.
* The program being tested might emit a variety of line endings, for example using `encoding/json` [never emits Windows line endings](https://github.com/golang/go/blob/master/src/encoding/json/indent.go#L63) whereas other libraries/programs might emit Windows line endings when running on Windows.

The `-text` flag added to `cmp` and `cmpenv` in this PR sidesteps these issues by canonicalizing the output to be compared to UNIX text format before doing the comparison.