### PR TITLE
testscript: relax constraints around actual source in cmp with update

### DIFF
--- a/testscript/cmd.go
+++ b/testscript/cmd.go
@@ -131,7 +131,7 @@ func (ts *TestScript) doCmdCmp(args []string, env bool) {
 	if text1 == text2 {
 		return
 	}
-	if ts.params.UpdateScripts && !env && (args[0] == "stdout" || args[0] == "stderr") {
+	if ts.params.UpdateScripts && !env {
 		if scriptFile, ok := ts.scriptFiles[absName2]; ok {
 			ts.scriptUpdates[scriptFile] = text1
 			return

--- a/testscript/testdata/testscript_update_script_actual_is_file.txt
+++ b/testscript/testdata/testscript_update_script_actual_is_file.txt
@@ -1,0 +1,19 @@
+unquote scripts/testscript.txt
+unquote testscript-new.txt
+testscript-update scripts
+cmp scripts/testscript.txt testscript-new.txt
+
+-- scripts/testscript.txt --
+>cmp got want
+>
+>-- got --
+>right
+>-- want --
+>wrong
+-- testscript-new.txt --
+>cmp got want
+>
+>-- got --
+>right
+>-- want --
+>right

--- a/testscript/testdata/testscript_update_script_expected_not_in_archive.txt
+++ b/testscript/testdata/testscript_update_script_expected_not_in_archive.txt
@@ -1,3 +1,5 @@
+# Verify that comparing stdout against a file not in the archive does nothing
+
 unquote scripts/testscript.txt
 cp scripts/testscript.txt unchanged
 ! testscript-update scripts

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -143,10 +143,10 @@ type Params struct {
 	// error will be ignored.
 	IgnoreMissedCoverage bool
 
-	// UpdateScripts specifies that if a `cmp` command fails and
-	// its first argument is `stdout` or `stderr` and its second argument
-	// refers to a file inside the testscript file, the command will succeed
-	// and the testscript file will be updated to reflect the actual output.
+	// UpdateScripts specifies that if a `cmp` command fails and its second
+	// argument refers to a file inside the testscript file, the command will
+	// succeed and the testscript file will be updated to reflect the actual
+	// content (which could be stdout, stderr or a real file).
 	//
 	// The content will be quoted with txtar.Quote if needed;
 	// a manual change will be needed if it is not unquoted in the


### PR DESCRIPTION
There are currently constraints on the actual source for a failed cmp
comparison when Params.UpdateScripts is true: the actual must be either
stdout or stderr.

However it's unclear why this constraint is necessary.

Indeed it's a painful constraint when the actual source in a comparison
is file written by a previous command.

Relax this constraint because, after discussion with @mvdan
and @rogpeppe, we believe it safe to do so.

Add a test for this new logic where the actual is a file that is part of
the archive.