### PR TITLE
readme: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Included are the following:
 - dirhash: calculate hashes over directory trees the same way that the Go tool does.
 - goproxytest: a GOPROXY implementation designed for test use.
 - gotooltest: Use the Go tool inside test scripts (see testscript below)
-- imports: list of known architectures and OSs, and support for reading import import statements.
+- imports: list of known architectures and OSs, and support for reading import statements.
 - modfile: read and write `go.mod` files while preserving formatting and comments.
 - module: module paths and versions.
 - par: do work in parallel.


### PR DESCRIPTION
The word "import" is repeated twice