### PR TITLE
testscript: some fixes for Plan 9

### DIFF
--- a/testscript/testdata/evalsymlink.txt
+++ b/testscript/testdata/evalsymlink.txt
@@ -2,6 +2,7 @@
 # matcher will have problems with external programs that uses the real path.
 # This script tests that $WORK is matched in a consistent way (also see #79).
 [windows] skip
+[plan9] skip
 exec pwd
 stdout ^$WORK$
 exec pwd -P

--- a/testscript/testdata/exec_path_change.txt
+++ b/testscript/testdata/exec_path_change.txt
@@ -3,7 +3,7 @@
 
 [!exec:go] skip
 
-env HOME=$WORK${/}home
+env HOME=$WORK${slash}home
 [windows] env USERPROFILE=$WORK\home
 [windows] env LOCALAPPDATA=$WORK\appdata
 
@@ -11,7 +11,7 @@ cd go
 exec go$exe version
 stdout 'go version'
 exec go$exe build
-env PATH=$WORK${/}go${:}$PATH
+env PATH=$WORK${slash}go${:}$PATH
 exec go$exe version
 stdout 'This is not go'
 

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -297,7 +297,7 @@ func (ts *TestScript) setup() string {
 			homeEnvName() + "=/no-home",
 			tempEnvName() + "=" + filepath.Join(ts.workdir, "tmp"),
 			"devnull=" + os.DevNull,
-			"/=" + string(os.PathSeparator),
+			"slash=" + string(os.PathSeparator),
 			":=" + string(os.PathListSeparator),
 		},
 		WorkDir: ts.workdir,

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -305,6 +305,9 @@ func (ts *TestScript) setup() string {
 		Cd:      ts.workdir,
 		ts:      ts,
 	}
+	if runtime.GOOS == "plan9" {
+		env.Vars = append(env.Vars, "path="+os.Getenv("path"))
+	}
 	// Must preserve SYSTEMROOT on Windows: https://github.com/golang/go/issues/25513 et al
 	if runtime.GOOS == "windows" {
 		env.Vars = append(env.Vars,


### PR DESCRIPTION
Plan 9 environment variables names can't have slash in them.
Removing this is not a big loss considering it's not available in
`cmd/go` testscripts and it's also not documented.

Update #90