### PR TITLE
ci: only build the master branch on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,15 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '**'
 name: Test
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         go-version: [1.14.x, 1.15.x]
         os: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
Otherwise, in the case a PR is created from a branch that is pushed to
this repo, we create a workflow run for the PR and the branch itself.