### PR TITLE
ci: include upcoming go1.16 in build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.14.x, 1.15.x, 1.16.0-beta1]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
+        stable: false
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@v2


### PR DESCRIPTION
Go 1.16 beta1 is released not too long ago. We should also build against it in the ci pipeline.