### PR TITLE
cmd/testscript: make -work actually work

### DIFF
--- a/cmd/testscript/testdata/work.txt
+++ b/cmd/testscript/testdata/work.txt
@@ -9,7 +9,9 @@
 unquote file.txt dir/file.txt
 
 testscript -v -work file.txt dir/file.txt
-stderr '\Qtemporary work directory: '$WORK'\E[/\\]tmp[/\\]'
+stderr '^temporary work directory: \Q'$WORK'\E[/\\]tmp[/\\]'
+stderr '^temporary work directory for file.txt: \Q'$WORK'\E[/\\]tmp[/\\]'
+stderr '^temporary work directory for dir[/\\]file.txt: \Q'$WORK'\E[/\\]tmp[/\\]'
 expandone $WORK/tmp/testscript*/file.txt/script.txt
 expandone $WORK/tmp/testscript*/file.txt1/script.txt
 


### PR DESCRIPTION
Turns out that we were only printing the cmd/testscript created work
directory for an argument. We also need to print (and preserve) the
working directory that is created by testscript itself when running the
script.

Combine this with a bit of light refactoring to improve readability.