### PR TITLE
testscript: rename testscript-update meta command to testscript

### DIFF
--- a/testscript/testdata/testscript_update_script.txt
+++ b/testscript/testdata/testscript_update_script.txt
@@ -1,6 +1,6 @@
 unquote scripts/testscript.txt
 unquote testscript-new.txt
-testscript-update scripts
+testscript -update scripts
 cmp scripts/testscript.txt testscript-new.txt
 
 -- scripts/testscript.txt --

--- a/testscript/testdata/testscript_update_script_actual_is_file.txt
+++ b/testscript/testdata/testscript_update_script_actual_is_file.txt
@@ -1,6 +1,6 @@
 unquote scripts/testscript.txt
 unquote testscript-new.txt
-testscript-update scripts
+testscript -update scripts
 cmp scripts/testscript.txt testscript-new.txt
 
 -- scripts/testscript.txt --

--- a/testscript/testdata/testscript_update_script_expected_not_in_archive.txt
+++ b/testscript/testdata/testscript_update_script_expected_not_in_archive.txt
@@ -2,7 +2,7 @@
 
 unquote scripts/testscript.txt
 cp scripts/testscript.txt unchanged
-! testscript-update scripts
+! testscript -update scripts
 cmp scripts/testscript.txt unchanged
 
 -- scripts/testscript.txt --

--- a/testscript/testdata/testscript_update_script_quote.txt
+++ b/testscript/testdata/testscript_update_script_quote.txt
@@ -1,6 +1,6 @@
 unquote scripts/testscript.txt
 unquote testscript-new.txt
-testscript-update scripts
+testscript -update scripts
 cmp scripts/testscript.txt testscript-new.txt
 
 -- scripts/testscript.txt --

--- a/testscript/testdata/testscript_update_script_stderr.txt
+++ b/testscript/testdata/testscript_update_script_stderr.txt
@@ -1,6 +1,6 @@
 unquote scripts/testscript.txt
 unquote testscript-new.txt
-testscript-update scripts
+testscript -update scripts
 cmp scripts/testscript.txt testscript-new.txt
 
 -- scripts/testscript.txt --


### PR DESCRIPTION
This allows us to use testscript the meta command in non-update mode.