### PR TITLE
gotooltest: skip flakey test on darwin

### DIFF
--- a/gotooltest/testdata/cover.txt
+++ b/gotooltest/testdata/cover.txt
@@ -1,5 +1,7 @@
 unquote scripts/exec.txt
 
+[darwin] skip 'Pending a fix for github.com/rogpeppe/go-internal/issues/130'
+
 # The module uses testscript itself.
 # Use the checked out module, based on where the test binary ran.
 go mod edit -replace=github.com/rogpeppe/go-internal=${GOINTERNAL_MODULE}


### PR DESCRIPTION
The need for a real fix for this is captured in #130