### PR TITLE
testscript: create a hidden temp directory by default

### DIFF
--- a/cmd/testscript/testdata/work.txt
+++ b/cmd/testscript/testdata/work.txt
@@ -9,11 +9,11 @@
 unquote file.txt dir/file.txt
 
 testscript -v -work file.txt dir/file.txt
-stderr '^temporary work directory: \Q'$WORK'\E[/\\]tmp[/\\]'
-stderr '^temporary work directory for file.txt: \Q'$WORK'\E[/\\]tmp[/\\]'
-stderr '^temporary work directory for dir[/\\]file.txt: \Q'$WORK'\E[/\\]tmp[/\\]'
-expandone $WORK/tmp/testscript*/file.txt/script.txt
-expandone $WORK/tmp/testscript*/file.txt1/script.txt
+stderr '^temporary work directory: \Q'$WORK'\E[/\\]\.tmp[/\\]'
+stderr '^temporary work directory for file.txt: \Q'$WORK'\E[/\\]\.tmp[/\\]'
+stderr '^temporary work directory for dir[/\\]file.txt: \Q'$WORK'\E[/\\]\.tmp[/\\]'
+expandone $WORK/.tmp/testscript*/file.txt/script.txt
+expandone $WORK/.tmp/testscript*/file.txt1/script.txt
 
 -- file.txt --
 >exec true

--- a/testscript/testdata/setupfiles.txt
+++ b/testscript/testdata/setupfiles.txt
@@ -1,6 +1,6 @@
 # check that the Setup function saw the unarchived files,
 # including the temp directory that's always created.
-setup-filenames a b tmp
+setup-filenames .tmp a b
 
 -- a --
 -- b/c --


### PR DESCRIPTION
When running a testscript, we currently create a temporary directory in
$WORK/tmp. This is problematic because it interacts badly with cmd/go
(which is used by go/packages) trying to resolve the ./... pattern from
$WORK.

Instead establish a temporary directory in workdir, but use a prefix
that ensures this directory will not be walked when resolving the ./...
pattern from workdir.