### PR TITLE
testscript: support writing to stdio from inside a custom command

### DIFF
--- a/testscript/testdata/commandstdio.txt
+++ b/testscript/testdata/commandstdio.txt
@@ -1,0 +1,24 @@
+[!exec:cat] stop
+
+# Add to stdout
+exec cat hello.text
+! stderr .
+stdout 'hello world'
+
+# Reverse stdout
+reverse 'hello world'
+! stderr .
+stdout 'dlrow olleh'
+
+# Test that we didn't mess anything up
+exec cat hello.text
+! stderr .
+stdout 'hello world'
+
+# Test stderr
+! reverse ''
+! stdout .
+stderr 'reverse can''t be blank'
+
+-- hello.text --
+hello world

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -779,6 +779,22 @@ func (ts *TestScript) Getenv(key string) string {
 	return ts.envMap[envvarname(key)]
 }
 
+// Stdout sets stdout
+func (ts *TestScript) Stdout(stdout string) {
+	if ts.stdout != "" {
+		ts.Logf("[stdout]\n%s", stdout)
+	}
+	ts.stdout = stdout
+}
+
+// Stderr sets stderr
+func (ts *TestScript) Stderr(stderr string) {
+	if ts.stderr != "" {
+		ts.Logf("[stderr]\n%s", stderr)
+	}
+	ts.stderr = stderr
+}
+
 // parse parses a single line as a list of space-separated arguments
 // subject to environment variable expansion (but not resplitting).
 // Single quotes around text disable splitting and expansion.

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -781,7 +781,7 @@ func (ts *TestScript) Getenv(key string) string {
 
 // Stdout sets stdout
 func (ts *TestScript) Stdout(stdout string) {
-	if ts.stdout != "" {
+	if stdout != "" {
 		ts.Logf("[stdout]\n%s", stdout)
 	}
 	ts.stdout = stdout
@@ -789,7 +789,7 @@ func (ts *TestScript) Stdout(stdout string) {
 
 // Stderr sets stderr
 func (ts *TestScript) Stderr(stderr string) {
-	if ts.stderr != "" {
+	if stderr != "" {
 		ts.Logf("[stderr]\n%s", stderr)
 	}
 	ts.stderr = stderr

--- a/testscript/testscript_test.go
+++ b/testscript/testscript_test.go
@@ -215,6 +215,27 @@ func TestScripts(t *testing.T) {
 					ts.Fatalf("testscript unexpectedly failed with errors: %q", t.failMsgs)
 				}
 			},
+			"reverse": func(ts *TestScript, neg bool, args []string) {
+				if len(args) != 1 {
+					ts.Fatalf("reverse expects exactly 1 argument")
+				}
+				// This is just here to test stderr
+				if len(args[0]) == 0 {
+					if neg {
+						ts.Stdout("")
+						ts.Stderr("reverse can't be blank")
+						return
+					}
+					ts.Fatalf("reverse can't be blank")
+				}
+				// Read the argument
+				reversed := ""
+				for _, char := range args[0] {
+					reversed = string(char) + reversed
+				}
+				ts.Stdout(reversed)
+				ts.Stderr("")
+			},
 		},
 		Setup: func(env *Env) error {
 			infos, err := ioutil.ReadDir(env.WorkDir)


### PR DESCRIPTION
This PR allows you to write to stderr and stdout from within a custom command. For example,

```go
func Test(t *testing.T) {
	p := testscript.Params{
		Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
			"render": render,
		},
	}
	testscript.Run(t, p)
}

func render(ts *testscript.TestScript, neg bool, args []string) {
    html, err := render.Render(ts.MkAbs(args))
    if err != nil {
      if neg {
        ts.Stdout("")
        ts.Stderr(err.Error())
        return
      }
      ts.Fatalf("Error rendering")
    }
    ts.Stdout(html)
    ts.Stderr("")
}
```

Allowing you to have a test like this:

```txt
render 'index.gohtml'
stdout '<h1>'
! stderr .

-- index.gohtml --
<html>
  <body>
    <h1>{{.}}</h1>
  </body>
</html>
```

And 

```txt
! render 'index.gohtml'
stderr 'bad HTML'
! stdout .

-- index.gohtml --
<html
```

Closes #139 