### PR TITLE
testscript: fix -testwork flag name in doc comments

### DIFF
--- a/testscript/doc.go
+++ b/testscript/doc.go
@@ -278,7 +278,7 @@ If Params.TestWork is true, it causes each test to log the name of its $WORK dir
 environment variable settings and also to leave that directory behind when it exits,
 for manual debugging of failing tests:
 
-	$ go test -run=Script -work
+	$ go test -run=Script -testwork
 	--- FAIL: TestScript (3.75s)
 	    --- FAIL: TestScript/install_rebuild_gopath (0.16s)
 	        script_test.go:223:


### PR DESCRIPTION
The `cmd/testscript` flag is called `-work`, but the `testscript` flag is called `-testwork` so as to not conflict with the Go tool's own `-work` flag. Update the docs to reflect this.