### PR TITLE
testscript: adapt to another Go 1.18 tip change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
     - name: Install Go
       env:
-        GO_COMMIT: d0dd26a88c019d54f22463daae81e785f5867565 # 2021-09-23
+        GO_COMMIT: d032b2b2c8235ef25275405f6655866f2c81661d # 2021-10-12
       run: |
         cd $HOME
         mkdir $HOME/gotip

--- a/testscript/exe_go118.go
+++ b/testscript/exe_go118.go
@@ -17,7 +17,7 @@ func mainStart() *testing.M {
 // Note: corpusEntry is an anonymous struct type used by some method stubs.
 type corpusEntry = struct {
 	Parent     string
-	Name       string
+	Path       string
 	Data       []byte
 	Values     []interface{}
 	Generation int


### PR DESCRIPTION
(see commit message)