### PR TITLE
testscript: print background command output on failure

### DIFF
--- a/testscript/cmd.go
+++ b/testscript/cmd.go
@@ -455,7 +455,10 @@ func (ts *TestScript) cmdWait(neg bool, args []string) {
 	if len(args) > 0 {
 		ts.Fatalf("usage: wait")
 	}
+	ts.waitBackground(true, neg)
+}
 
+func (ts *TestScript) waitBackground(checkStatus bool, neg bool) {
 	var stdouts, stderrs []string
 	for _, bg := range ts.background {
 		<-bg.wait
@@ -475,6 +478,9 @@ func (ts *TestScript) cmdWait(neg bool, args []string) {
 			stderrs = append(stderrs, cmdStderr)
 		}
 
+		if !checkStatus {
+			continue
+		}
 		if bg.cmd.ProcessState.Success() {
 			if bg.neg {
 				ts.Fatalf("unexpected command success")

--- a/testscript/testscript_test.go
+++ b/testscript/testscript_test.go
@@ -389,6 +389,7 @@ type fakeT struct {
 	log      bytes.Buffer
 	failMsgs []string
 	verbose  bool
+	failed   bool
 }
 
 var errAbort = errors.New("abort test")
@@ -398,6 +399,7 @@ func (t *fakeT) Skip(args ...interface{}) {
 }
 
 func (t *fakeT) Fatal(args ...interface{}) {
+	t.failed = true
 	t.failMsgs = append(t.failMsgs, fmt.Sprint(args...))
 	panic(errAbort)
 }
@@ -418,4 +420,8 @@ func (t *fakeT) Run(name string, f func(T)) {
 
 func (t *fakeT) Verbose() bool {
 	return t.verbose
+}
+
+func (t *fakeT) Failed() bool {
+	return t.failed
 }


### PR DESCRIPTION
When a script has failed, the output of the commands running in the
background can be useful to see, so display it then and also in verbose
mode.