### PR TITLE
testscript: add go:version condition

### DIFF
--- a/testscript/doc.go
+++ b/testscript/doc.go
@@ -105,6 +105,7 @@ should only run when the condition is satisfied. The predefined conditions are:
  - [link] for whether the OS has hard link support
  - [symlink] for whether the OS has symbolic link support
  - [exec:prog] for whether prog is available for execution (found by exec.LookPath)
+ - [go:version] for whether the Go version is at least the given version
 
 A condition can be negated: [!short] means to run the rest of the line
 when testing.Short() is false.

--- a/testscript/testdata/goversion.txt
+++ b/testscript/testdata/goversion.txt
@@ -1,0 +1,8 @@
+[!exec:sh] skip 'sh not found in $PATH'
+
+# test that the go: condition works for minimum supported versions of Go
+[go:1.16] exec sh -c 'exit 0'
+[go:1.17.1] exec sh -c 'exit 0'
+
+# test that the go:condition works for future versions of Go
+[go:2] exec sh -c 'exit 1'

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -552,32 +552,29 @@ func (ts *TestScript) applyScriptUpdates() {
 
 // condition reports whether the given condition is satisfied.
 func (ts *TestScript) condition(cond string) (bool, error) {
-	switch cond {
-	case "short":
+	switch {
+	case cond == "short":
 		return testing.Short(), nil
-	case "net":
+	case cond == "net":
 		return testenv.HasExternalNetwork(), nil
-	case "link":
+	case cond == "link":
 		return testenv.HasLink(), nil
-	case "symlink":
+	case cond == "symlink":
 		return testenv.HasSymlink(), nil
-	case runtime.GOOS, runtime.GOARCH:
-		return true, nil
+	case imports.KnownOS[cond]:
+		return cond == runtime.GOOS, nil
+	case imports.KnownArch[cond]:
+		return cond == runtime.GOARCH, nil
+	case strings.HasPrefix(cond, "exec:"):
+		prog := cond[len("exec:"):]
+		ok := execCache.Do(prog, func() interface{} {
+			_, err := execpath.Look(prog, ts.Getenv)
+			return err == nil
+		}).(bool)
+		return ok, nil
+	case ts.params.Condition != nil:
+		return ts.params.Condition(cond)
 	default:
-		if imports.KnownArch[cond] || imports.KnownOS[cond] {
-			return false, nil
-		}
-		if strings.HasPrefix(cond, "exec:") {
-			prog := cond[len("exec:"):]
-			ok := execCache.Do(prog, func() interface{} {
-				_, err := execpath.Look(prog, ts.Getenv)
-				return err == nil
-			}).(bool)
-			return ok, nil
-		}
-		if ts.params.Condition != nil {
-			return ts.params.Condition(cond)
-		}
 		ts.Fatalf("unknown condition %q", cond)
 		panic("unreachable")
 	}


### PR DESCRIPTION
Changes in Go's standard library can affect program behavior. For example, Go 1.18's `text/template` changes the behavior of the `and` and `or` to lazily evaluate their arguments. This can impact application behavior.

This PR adds a `go:version` condition that allows testscripts to be conditional on the Go version being used.