### PR TITLE
testscript: support named background commands

### DIFF
--- a/testscript/doc.go
+++ b/testscript/doc.go
@@ -152,6 +152,10 @@ The predefined commands are:
   test. At the end of the test, any remaining background processes are
   terminated using os.Interrupt (if supported) or os.Kill.
 
+  If the last token is '&word&` (where "word" is alphanumeric), the
+  command runs in the background but has a name, and can be waited
+  for specifically by passing the word to 'wait'.
+
   Standard input can be provided using the stdin command; this will be
   cleared after exec has been called.
 
@@ -197,12 +201,14 @@ The predefined commands are:
 - symlink file -> target
   Create file as a symlink to target. The -> (like in ls -l output) is required.
 
-- wait
+- wait [command]
   Wait for all 'exec' and 'go' commands started in the background (with the '&'
   token) to exit, and display success or failure status for them.
   After a call to wait, the 'stderr' and 'stdout' commands will apply to the
   concatenation of the corresponding streams of the background commands,
   in the order in which those commands were started.
+
+  If an argument is specified, it waits for just that command.
 
 When TestScript runs a script and the script fails, by default TestScript shows
 the execution of the most recent phase of the script (since the last # comment)

--- a/testscript/testdata/wait.txt
+++ b/testscript/testdata/wait.txt
@@ -20,6 +20,21 @@ exec echo bar &
 wait
 stdout 'foo\nbar'
 
+exec echo bg1 &b1&
+exec echo bg2 &b2&
+exec echo bg3 &b3&
+exec echo bg4 &b4&
+
+wait b3
+stdout bg3
+wait b2
+stdout bg2
+wait
+stdout 'bg1\nbg4'
+
+# We should be able to start several background processes and wait for them
+# individually.
+
 # The end of the test should interrupt or kill any remaining background
 # programs.
 [!exec:sleep] skip

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -286,6 +286,7 @@ type TestScript struct {
 }
 
 type backgroundCmd struct {
+	name string
 	cmd  *exec.Cmd
 	wait <-chan struct{}
 	neg  bool // if true, cmd should fail
@@ -396,7 +397,7 @@ func (ts *TestScript) run() {
 		if ts.t.Verbose() || hasFailed(ts.t) {
 			// In verbose mode or on test failure, we want to see what happened in the background
 			// processes too.
-			ts.waitBackground(false, false)
+			ts.waitBackground(false)
 		} else {
 			for _, bg := range ts.background {
 				<-bg.wait


### PR DESCRIPTION
This lets us wait for an individual background command rather
than all of them at once.