### PR TITLE
testscript: add Go compiler and version conditions

### DIFF
--- a/gotooltest/setup.go
+++ b/gotooltest/setup.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	goVersionRegex = regexp.MustCompile(`^go([1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
+	goVersionRegex = regexp.MustCompile(`^go([1-9][0-9]*)\.([1-9][0-9]*)$`)
 
 	goEnv struct {
 		GOROOT      string

--- a/gotooltest/setup.go
+++ b/gotooltest/setup.go
@@ -106,12 +106,6 @@ func Setup(p *testscript.Params) error {
 	p.Cmds["go"] = cmdGo
 	origCondition := p.Condition
 	p.Condition = func(cond string) (bool, error) {
-		if cond == "gc" || cond == "gccgo" {
-			// TODO this reflects the compiler that the current
-			// binary was built with but not necessarily the compiler
-			// that will be used.
-			return cond == runtime.Compiler, nil
-		}
 		if goVersionRegex.MatchString(cond) {
 			for _, v := range build.Default.ReleaseTags {
 				if cond == v {

--- a/gotooltest/setup.go
+++ b/gotooltest/setup.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"go/build"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -104,21 +103,6 @@ func Setup(p *testscript.Params) error {
 		p.Cmds = make(map[string]func(ts *testscript.TestScript, neg bool, args []string))
 	}
 	p.Cmds["go"] = cmdGo
-	origCondition := p.Condition
-	p.Condition = func(cond string) (bool, error) {
-		if goVersionRegex.MatchString(cond) {
-			for _, v := range build.Default.ReleaseTags {
-				if cond == v {
-					return true, nil
-				}
-			}
-			return false, nil
-		}
-		if origCondition == nil {
-			return false, fmt.Errorf("unknown condition %q", cond)
-		}
-		return origCondition(cond)
-	}
 	return nil
 }
 

--- a/testscript/doc.go
+++ b/testscript/doc.go
@@ -107,6 +107,7 @@ should only run when the condition is satisfied. The predefined conditions are:
  - [exec:prog] for whether prog is available for execution (found by exec.LookPath)
  - [gc] for whether Go was built with gc
  - [gccgo] for whether Go was built with gccgo
+ - [go1.x] for whether the Go version is 1.x or later
 
 A condition can be negated: [!short] means to run the rest of the line
 when testing.Short() is false.

--- a/testscript/doc.go
+++ b/testscript/doc.go
@@ -105,6 +105,8 @@ should only run when the condition is satisfied. The predefined conditions are:
  - [link] for whether the OS has hard link support
  - [symlink] for whether the OS has symbolic link support
  - [exec:prog] for whether prog is available for execution (found by exec.LookPath)
+ - [gc] for whether Go was built with gc
+ - [gccgo] for whether Go was built with gccgo
 
 A condition can be negated: [!short] means to run the rest of the line
 when testing.Short() is false.

--- a/testscript/testdata/cond.txt
+++ b/testscript/testdata/cond.txt
@@ -4,3 +4,8 @@
 [gc] exec sh -c 'echo gc >> go-compiler'
 [gccgo] exec sh -c 'echo gccgo >> go-compiler'
 grep '\A(gc|gccgo)\n\z' go-compiler
+
+# test that go version build tags are set
+[go1.1] exec sh -c 'echo go1.1 >> go-version'
+[go2.1] exec sh -c 'echo go2.1 >> go-version'
+grep '\Ago1\.1\n\z' go-version

--- a/testscript/testdata/cond.txt
+++ b/testscript/testdata/cond.txt
@@ -1,0 +1,6 @@
+[!exec:sh] skip 'sh not found in $PATH'
+
+# test that exactly one of gc and gccgo is set
+[gc] exec sh -c 'echo gc >> go-compiler'
+[gccgo] exec sh -c 'echo gccgo >> go-compiler'
+grep '\A(gc|gccgo)\n\z' go-compiler

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -592,6 +592,11 @@ func (ts *TestScript) condition(cond string) (bool, error) {
 			return err == nil
 		}).(bool)
 		return ok, nil
+	case cond == "gc" || cond == "gccgo":
+		// TODO this reflects the compiler that the current
+		// binary was built with but not necessarily the compiler
+		// that will be used.
+		return cond == runtime.Compiler, nil
 	case ts.params.Condition != nil:
 		return ts.params.Condition(cond)
 	default:

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"go/build"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -29,6 +30,8 @@ import (
 	"github.com/rogpeppe/go-internal/testenv"
 	"github.com/rogpeppe/go-internal/txtar"
 )
+
+var goVersionRegex = regexp.MustCompile(`^go([1-9][0-9]*)\.([1-9][0-9]*)$`)
 
 var execCache par.Cache
 
@@ -597,6 +600,13 @@ func (ts *TestScript) condition(cond string) (bool, error) {
 		// binary was built with but not necessarily the compiler
 		// that will be used.
 		return cond == runtime.Compiler, nil
+	case goVersionRegex.MatchString(cond):
+		for _, v := range build.Default.ReleaseTags {
+			if cond == v {
+				return true, nil
+			}
+		}
+		return false, nil
 	case ts.params.Condition != nil:
 		return ts.params.Condition(cond)
 	default:


### PR DESCRIPTION
As suggested by @mvdan in https://github.com/rogpeppe/go-internal/pull/150#issuecomment-1055495507. Replaces #150.