### PR TITLE
drop Go 1.16, add Go 1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,17 +11,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.17.x, 1.18.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        stable: false
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Test
       run: |
         go test ./...
@@ -41,7 +40,7 @@ jobs:
     steps:
     - name: Install Go
       env:
-        GO_COMMIT: d032b2b2c8235ef25275405f6655866f2c81661d # 2021-10-12
+        GO_COMMIT: 2cfbef438049fd4c3f73d1562773ad1f93900897 # 2022-06-09
       run: |
         cd $HOME
         mkdir $HOME/gotip
@@ -49,14 +48,14 @@ jobs:
 
         wget -O gotip.tar.gz https://go.googlesource.com/go/+archive/${GO_COMMIT}.tar.gz
         tar -xf gotip.tar.gz
-        echo "devel go1.18-${GO_COMMIT}" >VERSION
+        echo "devel go1.19-${GO_COMMIT}" >VERSION
 
         cd src
         ./make.bash
         echo "GOROOT=$HOME/gotip" >>$GITHUB_ENV
         echo "$HOME/gotip/bin" >>$GITHUB_PATH
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Test
       run: |
         go version

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/rogpeppe/go-internal
 
-go 1.16
+go 1.17
 
 require github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e


### PR DESCRIPTION
(see commit message)

