### PR TITLE
testscript: add pty/ptyout commands

### DIFF
--- a/testscript/doc.go
+++ b/testscript/doc.go
@@ -205,6 +205,16 @@ The predefined commands are:
     Apply the grep command (see above) to the standard output
     from the most recent exec or wait command.
 
+  - ttyin [-stdin] file
+    Attach the next exec command to a controlling pseudo-terminal, and use the
+    contents of the given file as the raw terminal input. If -stdin is specified,
+    also attach the terminal to standard input.
+    Note that this does not attach the terminal to standard output/error.
+
+  - [!] ttyout [-count=N] pattern
+    Apply the grep command (see above) to the raw controlling terminal output
+    from the most recent exec command.
+
   - stop [message]
     Stop the test early (marking it as passing), including the message if given.
 

--- a/testscript/envvarname.go
+++ b/testscript/envvarname.go
@@ -1,7 +1,0 @@
-//go:build !windows
-
-package testscript
-
-func envvarname(k string) string {
-	return k
-}

--- a/testscript/envvarname_windows.go
+++ b/testscript/envvarname_windows.go
@@ -1,7 +1,0 @@
-package testscript
-
-import "strings"
-
-func envvarname(k string) string {
-	return strings.ToLower(k)
-}

--- a/testscript/internal/pty/pty.go
+++ b/testscript/internal/pty/pty.go
@@ -1,0 +1,62 @@
+//go:build linux || darwin
+// +build linux darwin
+
+package pty
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+const Supported = true
+
+func SetCtty(cmd *exec.Cmd, tty *os.File) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setctty: true,
+		Setsid:  true,
+		Ctty:    3,
+	}
+	cmd.ExtraFiles = []*os.File{tty}
+}
+
+func Open() (pty, tty *os.File, err error) {
+	p, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open pty multiplexer: %v", err)
+	}
+	defer func() {
+		if err != nil {
+			p.Close()
+		}
+	}()
+
+	name, err := ptyName(p)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to obtain tty name: %v", err)
+	}
+
+	if err := ptyGrant(p); err != nil {
+		return nil, nil, fmt.Errorf("failed to grant pty: %v", err)
+	}
+
+	if err := ptyUnlock(p); err != nil {
+		return nil, nil, fmt.Errorf("failed to unlock pty: %v", err)
+	}
+
+	t, err := os.OpenFile(name, os.O_RDWR|syscall.O_NOCTTY, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open TTY: %v", err)
+	}
+
+	return p, t, nil
+}
+
+func ioctl(f *os.File, name string, cmd, ptr uintptr) error {
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), cmd, ptr)
+	if err != 0 {
+		return fmt.Errorf("%s ioctl failed: %v", name, err)
+	}
+	return nil
+}

--- a/testscript/internal/pty/pty_darwin.go
+++ b/testscript/internal/pty/pty_darwin.go
@@ -1,0 +1,32 @@
+package pty
+
+import (
+	"bytes"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func ptyName(f *os.File) (string, error) {
+	// Parameter length is encoded in the low 13 bits of the top word.
+	// See https://github.com/apple/darwin-xnu/blob/2ff845c2e0/bsd/sys/ioccom.h#L69-L77
+	const IOCPARM_MASK = 0x1fff
+	const TIOCPTYGNAME_PARM_LEN = (syscall.TIOCPTYGNAME >> 16) & IOCPARM_MASK
+	out := make([]byte, TIOCPTYGNAME_PARM_LEN)
+
+	err := ioctl(f, "TIOCPTYGNAME", syscall.TIOCPTYGNAME, uintptr(unsafe.Pointer(&out[0])))
+	if err != nil {
+		return "", err
+	}
+
+	i := bytes.IndexByte(out, 0x00)
+	return string(out[:i]), nil
+}
+
+func ptyGrant(f *os.File) error {
+	return ioctl(f, "TIOCPTYGRANT", syscall.TIOCPTYGRANT, 0)
+}
+
+func ptyUnlock(f *os.File) error {
+	return ioctl(f, "TIOCPTYUNLK", syscall.TIOCPTYUNLK, 0)
+}

--- a/testscript/internal/pty/pty_linux.go
+++ b/testscript/internal/pty/pty_linux.go
@@ -1,0 +1,26 @@
+package pty
+
+import (
+	"os"
+	"strconv"
+	"syscall"
+	"unsafe"
+)
+
+func ptyName(f *os.File) (string, error) {
+	var out uint
+	err := ioctl(f, "TIOCGPTN", syscall.TIOCGPTN, uintptr(unsafe.Pointer(&out)))
+	if err != nil {
+		return "", err
+	}
+	return "/dev/pts/" + strconv.Itoa(int(out)), nil
+}
+
+func ptyGrant(f *os.File) error {
+	return nil
+}
+
+func ptyUnlock(f *os.File) error {
+	var zero int
+	return ioctl(f, "TIOCSPTLCK", syscall.TIOCSPTLCK, uintptr(unsafe.Pointer(&zero)))
+}

--- a/testscript/internal/pty/pty_unsupported.go
+++ b/testscript/internal/pty/pty_unsupported.go
@@ -1,0 +1,21 @@
+//go:build !linux && !darwin
+// +build !linux,!darwin
+
+package pty
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+const Supported = false
+
+func SetCtty(cmd *exec.Cmd, tty *os.File) error {
+	panic("SetCtty called on unsupported platform")
+}
+
+func Open() (pty, tty *os.File, err error) {
+	return nil, nil, fmt.Errorf("pty unsupported on %s", runtime.GOOS)
+}

--- a/testscript/testdata/pty.txt
+++ b/testscript/testdata/pty.txt
@@ -1,0 +1,10 @@
+[!linux] [!darwin] skip
+
+ttyin secretwords.txt
+terminalprompt
+ttyout 'magic words'
+! stderr .
+! stdout .
+
+-- secretwords.txt --
+SQUEAMISHOSSIFRAGE

--- a/testscript/testdata/pty.txt
+++ b/testscript/testdata/pty.txt
@@ -1,4 +1,5 @@
 [!linux] [!darwin] skip
+[darwin] [go1.20] skip # https://go.dev/issue/61779
 
 ttyin secretwords.txt
 terminalprompt

--- a/testscript/testscript_test.go
+++ b/testscript/testscript_test.go
@@ -58,6 +58,22 @@ func signalCatcher() int {
 	return 0
 }
 
+func terminalPrompt() int {
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		fmt.Println(err)
+		return 1
+	}
+	tty.WriteString("The magic words are: ")
+	var words string
+	fmt.Fscanln(tty, &words)
+	if words != "SQUEAMISHOSSIFRAGE" {
+		fmt.Println(words)
+		return 42
+	}
+	return 0
+}
+
 func TestMain(m *testing.M) {
 	timeSince = func(t time.Time) time.Duration {
 		return 0
@@ -65,10 +81,11 @@ func TestMain(m *testing.M) {
 
 	showVerboseEnv = false
 	os.Exit(RunMain(m, map[string]func() int{
-		"printargs":     printArgs,
-		"fprintargs":    fprintArgs,
-		"status":        exitWithStatus,
-		"signalcatcher": signalCatcher,
+		"printargs":      printArgs,
+		"fprintargs":     fprintArgs,
+		"status":         exitWithStatus,
+		"signalcatcher":  signalCatcher,
+		"terminalprompt": terminalPrompt,
 	}))
 }
 


### PR DESCRIPTION
This allows testing commands that open `/dev/tty` to interact with the user separately from stdin/stdout, like age.

See https://github.com/FiloSottile/age/blob/084c974f5393e5d2776fb1bb3a35eeed271a32fa/cmd/age/testdata/terminal.txt and https://github.com/FiloSottile/age/blob/084c974f5393e5d2776fb1bb3a35eeed271a32fa/cmd/age/testdata/scrypt.txt for example scripts.