### PR TITLE
testscript: remove leading newline before results

### DIFF
--- a/testscript/testdata/big_diff.txt
+++ b/testscript/testdata/big_diff.txt
@@ -7,7 +7,6 @@ env
 cmpenv stdout stdout.golden
 
 -- stdout.golden --
-
 > cmp a b
 FAIL: $$WORK${/}dir${/}script.txt:1: large files a and b differ
 -- dir/script.txt --

--- a/testscript/testdata/long_diff.txt
+++ b/testscript/testdata/long_diff.txt
@@ -110,7 +110,6 @@ cmpenv stdout stdout.golden
 >a
 >a
 -- stdout.golden --
-
 > cmp a b
 --- a
 +++ b

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -425,7 +425,7 @@ func (ts *TestScript) run() {
 
 		markTime()
 		// Flush testScript log to testing.T log.
-		ts.t.Log("\n" + ts.abbrev(ts.log.String()))
+		ts.t.Log(ts.abbrev(ts.log.String()))
 	}()
 	defer func() {
 		ts.deferred()


### PR DESCRIPTION
Unlike `go test`, the `testscript` command prints a blank line before either 'PASS' or 'FAIL' and its other output:

```
testscript test.txtar

PASS
```

This makes it awkward to use in a loop over many scripts, one at a time. For example:

```sh
for TS in *.txtar; do
    echo -n "${TS}... "
    testscript ${TS}
done
```

The desired output is:

        test1.txtar... PASS
        test2.txtar... PASS
        ...

But instead, with this leading newline, we see:

        test1.txtar...
        PASS
        test2.txtar...
        PASS
        ...
        
This commit removes the newline.