### PR TITLE
Use 0o prefix for octal literals, and `gofumpt` all files

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -46,7 +46,6 @@ type Cache struct {
 // to share a cache directory (for example, if the directory were stored
 // in a network file system). File locking is notoriously unreliable in
 // network file systems and may not suffice to protect the cache.
-//
 func Open(dir string) (*Cache, error) {
 	info, err := os.Stat(dir)
 	if err != nil {
@@ -57,11 +56,11 @@ func Open(dir string) (*Cache, error) {
 	}
 	for i := 0; i < 256; i++ {
 		name := filepath.Join(dir, fmt.Sprintf("%02x", i))
-		if err := os.MkdirAll(name, 0777); err != nil {
+		if err := os.MkdirAll(name, 0o777); err != nil {
 			return nil, err
 		}
 	}
-	f, err := os.OpenFile(filepath.Join(dir, "log.txt"), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
+	f, err := os.OpenFile(filepath.Join(dir, "log.txt"), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o666)
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +282,7 @@ func (c *Cache) Trim() {
 		c.trimSubdir(subdir, cutoff)
 	}
 
-	ioutil.WriteFile(filepath.Join(c.dir, "trim.txt"), []byte(fmt.Sprintf("%d", now.Unix())), 0666)
+	ioutil.WriteFile(filepath.Join(c.dir, "trim.txt"), []byte(fmt.Sprintf("%d", now.Unix())), 0o666)
 }
 
 // trimSubdir trims a single cache subdirectory.
@@ -337,7 +336,7 @@ func (c *Cache) putIndexEntry(id ActionID, out OutputID, size int64, allowVerify
 		}
 	}
 	file := c.fileName(id, "a")
-	if err := ioutil.WriteFile(file, entry, 0666); err != nil {
+	if err := ioutil.WriteFile(file, entry, 0o666); err != nil {
 		os.Remove(file)
 		return err
 	}
@@ -414,7 +413,7 @@ func (c *Cache) copyFile(file io.ReadSeeker, out OutputID, size int64) error {
 	if err == nil && info.Size() > size { // shouldn't happen but fix in case
 		mode |= os.O_TRUNC
 	}
-	f, err := os.OpenFile(name, mode, 0666)
+	f, err := os.OpenFile(name, mode, 0o666)
 	if err != nil {
 		return err
 	}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -31,7 +31,7 @@ func TestBasic(t *testing.T) {
 	}
 
 	cdir := filepath.Join(dir, "c1")
-	if err := os.Mkdir(cdir, 0777); err != nil {
+	if err := os.Mkdir(cdir, 0o777); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cache/default.go
+++ b/cache/default.go
@@ -38,7 +38,7 @@ func initDefaultCache() {
 	if dir == "off" {
 		return
 	}
-	if err := os.MkdirAll(dir, 0777); err != nil {
+	if err := os.MkdirAll(dir, 0o777); err != nil {
 		if showWarnings {
 			fmt.Fprintf(os.Stderr, "go: disabling cache (%s) due to initialization failure: %s\n", dir, err)
 		}
@@ -46,7 +46,7 @@ func initDefaultCache() {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "README")); err != nil {
 		// Best effort.
-		ioutil.WriteFile(filepath.Join(dir, "README"), []byte(cacheREADME), 0666)
+		ioutil.WriteFile(filepath.Join(dir, "README"), []byte(cacheREADME), 0o666)
 	}
 
 	c, err := Open(dir)

--- a/cmd/testscript/main.go
+++ b/cmd/testscript/main.go
@@ -123,7 +123,7 @@ func mainerr() (retErr error) {
 		}
 
 		runDir := filepath.Join(td, dirName)
-		if err := os.Mkdir(runDir, 0777); err != nil {
+		if err := os.Mkdir(runDir, 0o777); err != nil {
 			return fmt.Errorf("failed to create a run directory within %v for %v: %v", td, renderFilename(filename), err)
 		}
 		if err := tr.run(runDir, filename); err != nil {
@@ -160,7 +160,7 @@ func (tr *testRunner) run(runDir, filename string) error {
 
 	mods := filepath.Join(runDir, goModProxyDir)
 
-	if err := os.MkdirAll(mods, 0777); err != nil {
+	if err := os.MkdirAll(mods, 0o777); err != nil {
 		return fmt.Errorf("failed to create goModProxy dir: %v", err)
 	}
 
@@ -198,7 +198,7 @@ func (tr *testRunner) run(runDir, filename string) error {
 
 	scriptFile := filepath.Join(runDir, "script.txtar")
 
-	if err := ioutil.WriteFile(scriptFile, txtar.Format(&script), 0666); err != nil {
+	if err := ioutil.WriteFile(scriptFile, txtar.Format(&script), 0o666); err != nil {
 		return fmt.Errorf("failed to write script for %v: %v", renderFilename(filename), err)
 	}
 
@@ -310,13 +310,12 @@ func (tr *testRunner) run(runDir, filename string) error {
 				ar.Files[i] = newF
 			}
 		}
-		if err := ioutil.WriteFile(filename, txtar.Format(ar), 0666); err != nil {
+		if err := ioutil.WriteFile(filename, txtar.Format(ar), 0o666); err != nil {
 			return fmt.Errorf("failed to write script back to %v for -update: %v", renderFilename(filename), err)
 		}
 	}
 
 	return nil
-
 }
 
 var (

--- a/cmd/txtar-addmod/addmod.go
+++ b/cmd/txtar-addmod/addmod.go
@@ -15,7 +15,6 @@
 // very large files into testdata/mod.
 //
 // It is acceptable to edit the archive afterward to remove or shorten files.
-//
 package main
 
 import (
@@ -107,7 +106,7 @@ func main1() int {
 
 	exitCode := 0
 	for _, arg := range modules {
-		if err := ioutil.WriteFile(filepath.Join(tmpdir, "go.mod"), []byte("module m\n"), 0666); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(tmpdir, "go.mod"), []byte("module m\n"), 0o666); err != nil {
 			fatalf("%v", err)
 		}
 		run(goCmd, "get", "-d", arg)
@@ -202,7 +201,7 @@ func main1() int {
 				break
 			}
 		} else {
-			if err := ioutil.WriteFile(filepath.Join(targetDir, modDir+".txtar"), data, 0666); err != nil {
+			if err := ioutil.WriteFile(filepath.Join(targetDir, modDir+".txtar"), data, 0o666); err != nil {
 				log.Printf("%s: %v", arg, err)
 				exitCode = 1
 				continue

--- a/cmd/txtar-x/extract_test.go
+++ b/cmd/txtar-x/extract_test.go
@@ -38,7 +38,7 @@ func unquote(ts *testscript.TestScript, neg bool, args []string) {
 		ts.Check(err)
 		data = bytes.Replace(data, []byte("\n>"), []byte("\n"), -1)
 		data = bytes.TrimPrefix(data, []byte(">"))
-		err = ioutil.WriteFile(file, data, 0666)
+		err = ioutil.WriteFile(file, data, 0o666)
 		ts.Check(err)
 	}
 }

--- a/dirhash/hash_test.go
+++ b/dirhash/hash_test.go
@@ -52,10 +52,10 @@ func TestHashDir(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
-	if err := ioutil.WriteFile(filepath.Join(dir, "xyz"), []byte("data for xyz"), 0666); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(dir, "xyz"), []byte("data for xyz"), 0o666); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, "abc"), []byte("data for abc"), 0666); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(dir, "abc"), []byte("data for abc"), 0o666); err != nil {
 		t.Fatal(err)
 	}
 	want := htop("h1", fmt.Sprintf("%s  %s\n%s  %s\n", h("data for abc"), "prefix/abc", h("data for xyz"), "prefix/xyz"))
@@ -110,16 +110,16 @@ func TestDirFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
-	if err := ioutil.WriteFile(filepath.Join(dir, "xyz"), []byte("data for xyz"), 0666); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(dir, "xyz"), []byte("data for xyz"), 0o666); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, "abc"), []byte("data for abc"), 0666); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(dir, "abc"), []byte("data for abc"), 0o666); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0777); err != nil {
+	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, "subdir", "xyz"), []byte("data for subdir xyz"), 0666); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(dir, "subdir", "xyz"), []byte("data for subdir xyz"), 0o666); err != nil {
 		t.Fatal(err)
 	}
 	prefix := "foo/bar@v2.3.4"

--- a/lockedfile/lockedfile.go
+++ b/lockedfile/lockedfile.go
@@ -64,16 +64,16 @@ func Open(name string) (*File, error) {
 
 // Create is like os.Create, but returns a write-locked file.
 func Create(name string) (*File, error) {
-	return OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+	return OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o666)
 }
 
-// Edit creates the named file with mode 0666 (before umask),
+// Edit creates the named file with mode 0o666 (before umask),
 // but does not truncate existing contents.
 //
 // If Edit succeeds, methods on the returned File can be used for I/O.
 // The associated file descriptor has mode O_RDWR and the file is write-locked.
 func Edit(name string) (*File, error) {
-	return OpenFile(name, os.O_RDWR|os.O_CREATE, 0666)
+	return OpenFile(name, os.O_RDWR|os.O_CREATE, 0o666)
 }
 
 // Close unlocks and closes the underlying file.

--- a/lockedfile/lockedfile_test.go
+++ b/lockedfile/lockedfile_test.go
@@ -157,7 +157,7 @@ func TestCanLockExistingFile(t *testing.T) {
 	defer remove()
 	path := filepath.Join(dir, "existing.txt")
 
-	if err := ioutil.WriteFile(path, []byte("ok"), 0777); err != nil {
+	if err := ioutil.WriteFile(path, []byte("ok"), 0o777); err != nil {
 		t.Fatalf("ioutil.WriteFile: %v", err)
 	}
 
@@ -203,7 +203,7 @@ func TestSpuriousEDEADLK(t *testing.T) {
 		}
 		defer b.Close()
 
-		if err := ioutil.WriteFile(filepath.Join(dir, "locked"), []byte("ok"), 0666); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(dir, "locked"), []byte("ok"), 0o666); err != nil {
 			t.Fatal(err)
 		}
 

--- a/lockedfile/mutex.go
+++ b/lockedfile/mutex.go
@@ -52,7 +52,7 @@ func (mu *Mutex) Lock() (unlock func(), err error) {
 	// in the future, it should call OpenFile with O_RDONLY and will require the
 	// files must be readable, so we should not let the caller make any
 	// assumptions about Mutex working with write-only files.
-	f, err := OpenFile(mu.Path, os.O_RDWR|os.O_CREATE, 0666)
+	f, err := OpenFile(mu.Path, os.O_RDWR|os.O_CREATE, 0o666)
 	if err != nil {
 		return nil, err
 	}

--- a/testscript/cmd.go
+++ b/testscript/cmd.go
@@ -186,16 +186,16 @@ func (ts *TestScript) cmdCp(neg bool, args []string) {
 		case "stdout":
 			src = arg
 			data = []byte(ts.stdout)
-			mode = 0666
+			mode = 0o666
 		case "stderr":
 			src = arg
 			data = []byte(ts.stderr)
-			mode = 0666
+			mode = 0o666
 		default:
 			src = ts.MkAbs(arg)
 			info, err := os.Stat(src)
 			ts.Check(err)
-			mode = info.Mode() & 0777
+			mode = info.Mode() & 0o777
 			data, err = ioutil.ReadFile(src)
 			ts.Check(err)
 		}
@@ -306,7 +306,7 @@ func (ts *TestScript) cmdExists(neg bool, args []string) {
 		if err != nil && !neg {
 			ts.Fatalf("%s does not exist", file)
 		}
-		if err == nil && !neg && readonly && info.Mode()&0222 != 0 {
+		if err == nil && !neg && readonly && info.Mode()&0o222 != 0 {
 			ts.Fatalf("%s exists but is writable", file)
 		}
 	}
@@ -321,7 +321,7 @@ func (ts *TestScript) cmdMkdir(neg bool, args []string) {
 		ts.Fatalf("usage: mkdir dir...")
 	}
 	for _, arg := range args {
-		ts.Check(os.MkdirAll(ts.MkAbs(arg), 0777))
+		ts.Check(os.MkdirAll(ts.MkAbs(arg), 0o777))
 	}
 }
 
@@ -346,7 +346,7 @@ func (ts *TestScript) cmdUnquote(neg bool, args []string) {
 		ts.Check(err)
 		data, err = txtar.Unquote(data)
 		ts.Check(err)
-		err = ioutil.WriteFile(file, data, 0666)
+		err = ioutil.WriteFile(file, data, 0o666)
 		ts.Check(err)
 	}
 }
@@ -457,7 +457,7 @@ func (ts *TestScript) cmdUNIX2DOS(neg bool, args []string) {
 		ts.Check(err)
 		dosData, err := unix2DOS(data)
 		ts.Check(err)
-		if err := ioutil.WriteFile(filename, dosData, 0666); err != nil {
+		if err := ioutil.WriteFile(filename, dosData, 0o666); err != nil {
 			ts.Fatalf("%s: %v", filename, err)
 		}
 	}

--- a/testscript/exe.go
+++ b/testscript/exe.go
@@ -78,7 +78,7 @@ func RunMain(m TestingM, commands map[string]func() int) (exitCode int) {
 			}
 		}()
 		bindir := filepath.Join(tmpdir, "bin")
-		if err := os.MkdirAll(bindir, 0777); err != nil {
+		if err := os.MkdirAll(bindir, 0o777); err != nil {
 			log.Printf("could not set up PATH binary directory: %v", err)
 			return 2
 		}
@@ -91,7 +91,7 @@ func RunMain(m TestingM, commands map[string]func() int) (exitCode int) {
 		// profiles into the main profile.
 		if coverProfile() != "" {
 			coverdir := filepath.Join(tmpdir, "cover")
-			if err := os.MkdirAll(coverdir, 0777); err != nil {
+			if err := os.MkdirAll(coverdir, 0o777); err != nil {
 				log.Printf("could not set up cover directory: %v", err)
 				return 2
 			}
@@ -181,7 +181,7 @@ func copyBinary(from, to string) error {
 			return nil
 		}
 	}
-	writer, err := os.OpenFile(to, os.O_WRONLY|os.O_CREATE, 0777)
+	writer, err := os.OpenFile(to, os.O_WRONLY|os.O_CREATE, 0o777)
 	if err != nil {
 		return err
 	}
@@ -284,6 +284,7 @@ func (nopTestDeps) StopCPUProfile() {}
 func (nopTestDeps) WriteProfileTo(name string, w io.Writer, debug int) error {
 	return nil
 }
+
 func (nopTestDeps) ImportPath() string {
 	return ""
 }

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -324,7 +324,7 @@ func (ts *TestScript) setup() string {
 	// cmd/go as it walks directories to match the ./... pattern.
 	tmpDir := filepath.Join(ts.workdir, ".tmp")
 
-	ts.Check(os.MkdirAll(tmpDir, 0777))
+	ts.Check(os.MkdirAll(tmpDir, 0o777))
 	env := &Env{
 		Vars: []string{
 			"WORK=" + ts.workdir, // must be first for ts.abbrev
@@ -364,8 +364,8 @@ func (ts *TestScript) setup() string {
 	for _, f := range a.Files {
 		name := ts.MkAbs(ts.expand(f.Name))
 		ts.scriptFiles[name] = f.Name
-		ts.Check(os.MkdirAll(filepath.Dir(name), 0777))
-		ts.Check(ioutil.WriteFile(name, f.Data, 0666))
+		ts.Check(os.MkdirAll(filepath.Dir(name), 0o777))
+		ts.Check(ioutil.WriteFile(name, f.Data, 0o666))
 	}
 	// Run any user-defined setup.
 	if ts.params.Setup != nil {
@@ -582,7 +582,7 @@ func (ts *TestScript) applyScriptUpdates() {
 			panic("script update file not found")
 		}
 	}
-	if err := ioutil.WriteFile(ts.file, txtar.Format(ts.archive), 0666); err != nil {
+	if err := ioutil.WriteFile(ts.file, txtar.Format(ts.archive), 0o666); err != nil {
 		ts.t.Fatal("cannot update script: ", err)
 	}
 	ts.Logf("%s updated", ts.file)
@@ -890,14 +890,14 @@ func (ts *TestScript) parse(line string) []string {
 }
 
 func removeAll(dir string) error {
-	// module cache has 0444 directories;
+	// module cache has 0o444 directories;
 	// make them writable in order to remove content.
 	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil // ignore errors walking in file system
 		}
 		if info.IsDir() {
-			os.Chmod(path, 0777)
+			os.Chmod(path, 0o777)
 		}
 		return nil
 	})

--- a/testscript/testscript_test.go
+++ b/testscript/testscript_test.go
@@ -49,7 +49,7 @@ func signalCatcher() int {
 	signal.Notify(c, os.Interrupt)
 	// Create a file so that the test can know that
 	// we will catch the signal.
-	if err := ioutil.WriteFile("catchsignal", nil, 0666); err != nil {
+	if err := ioutil.WriteFile("catchsignal", nil, 0o666); err != nil {
 		fmt.Println(err)
 		return 1
 	}
@@ -77,7 +77,7 @@ func TestCRLFInput(t *testing.T) {
 	}()
 	tf := filepath.Join(td, "script.txt")
 	contents := []byte("exists output.txt\r\n-- output.txt --\r\noutput contents")
-	if err := ioutil.WriteFile(tf, contents, 0644); err != nil {
+	if err := ioutil.WriteFile(tf, contents, 0o644); err != nil {
 		t.Fatalf("failed to write to %v: %v", tf, err)
 	}
 	t.Run("_", func(t *testing.T) {

--- a/txtar/archive.go
+++ b/txtar/archive.go
@@ -6,15 +6,15 @@
 //
 // The goals for the format are:
 //
-//	- be trivial enough to create and edit by hand.
-//	- be able to store trees of text files describing go command test cases.
-//	- diff nicely in git history and code reviews.
+//   - be trivial enough to create and edit by hand.
+//   - be able to store trees of text files describing go command test cases.
+//   - diff nicely in git history and code reviews.
 //
 // Non-goals include being a completely general archive format,
 // storing binary data, storing file modes, storing special files like
 // symbolic links, and so on.
 //
-// Txtar format
+// # Txtar format
 //
 // A txtar archive is zero or more comment lines and then a sequence of file entries.
 // Each file entry begins with a file marker line of the form "-- FILENAME --"
@@ -206,11 +206,11 @@ func Write(a *Archive, dir string) error {
 		}
 		fp = filepath.Join(dir, fp)
 
-		if err := os.MkdirAll(filepath.Dir(fp), 0777); err != nil {
+		if err := os.MkdirAll(filepath.Dir(fp), 0o777); err != nil {
 			return err
 		}
 		// Avoid overwriting existing files by using O_EXCL.
-		out, err := os.OpenFile(fp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666)
+		out, err := os.OpenFile(fp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o666)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Since Go 1.13, octal literals can be written using an `0o` prefix, instead of the (slightly) ambiguous `0`. Indeed, `gofumpt` insists on this, and those of us who use `gopls` with `gofumpt` enabled have our octal literals rewritten for us automatically.

This commit applies that change, along with some other minor `gofumpt`-age, including adding or removing blank lines and reformatting doc comments.
