### PR TITLE
txtar-c: add -script flag

### DIFF
--- a/cmd/txtar-c/savedir.go
+++ b/cmd/txtar-c/savedir.go
@@ -10,7 +10,6 @@
 //
 // See https://godoc.org/github.com/rogpeppe/go-internal/txtar for details of the format
 // and how to parse a txtar file.
-//
 package main
 
 import (
@@ -35,8 +34,9 @@ func usage() {
 }
 
 var (
-	quoteFlag = flag.Bool("quote", false, "quote files that contain txtar file markers instead of failing")
-	allFlag   = flag.Bool("a", false, "include dot files too")
+	quoteFlag  = flag.Bool("quote", false, "quote files that contain txtar file markers instead of failing")
+	scriptFlag = flag.String("script", "", "include testscript `FILE` (after any 'unquote' lines)")
+	allFlag    = flag.Bool("a", false, "include dot files too")
 )
 
 func main() {
@@ -105,7 +105,13 @@ func main1() int {
 		})
 		return nil
 	})
-
+	if *scriptFlag != "" {
+		script, err := os.ReadFile(*scriptFlag)
+		if err != nil {
+			log.Fatal(err)
+		}
+		a.Comment = append(a.Comment, script...)
+	}
 	data := txtar.Format(a)
 	os.Stdout.Write(data)
 

--- a/cmd/txtar-c/testdata/script.txtar
+++ b/cmd/txtar-c/testdata/script.txtar
@@ -1,0 +1,35 @@
+unquote expect
+# With the -script flag, it should include the contents of test.txtar as a comment
+exec txtar-c -script test.txtar blah
+cmp stdout expect
+
+-- test.txtar --
+exec echo hello
+
+-- blah/go.mod --
+module example.com/blah
+
+-- blah/main.go --
+package main
+
+import "fmt"
+
+func main() {
+  fmt.Println("Hello, world!")
+}
+
+-- expect --
+>exec echo hello
+>
+>-- go.mod --
+>module example.com/blah
+>
+>-- main.go --
+>package main
+>
+>import "fmt"
+>
+>func main() {
+>  fmt.Println("Hello, world!")
+>}
+>

--- a/cmd/txtar-c/testdata/script_quote.txtar
+++ b/cmd/txtar-c/testdata/script_quote.txtar
@@ -1,0 +1,43 @@
+unquote expect
+unquote blah/needsquote.txtar
+# With both -script and -quote, it should include test.txtar after any 'unquote's
+exec txtar-c -quote -script test.txtar blah
+cmp stdout expect
+
+-- test.txtar --
+exec echo hello
+
+-- blah/go.mod --
+module example.com/blah
+
+-- blah/main.go --
+package main
+
+import "fmt"
+
+func main() {
+  fmt.Println("Hello, world!")
+}
+
+-- blah/needsquote.txtar --
+>-- file_entry.txt --
+
+-- expect --
+>unquote needsquote.txtar
+>exec echo hello
+>
+>-- go.mod --
+>module example.com/blah
+>
+>-- main.go --
+>package main
+>
+>import "fmt"
+>
+>func main() {
+>  fmt.Println("Hello, world!")
+>}
+>
+>-- needsquote.txtar --
+>>-- file_entry.txt --
+>>


### PR DESCRIPTION
TL;DR have `txtar-c` include an optional test script in the archive it creates.

## Use case

Suppose we want to use the marvellous `testscript` runner to run a given script against a set of files. For example, we might want to test a directory containing Go files using some script `test.txtar`:

```
exec go test
```

Of course, we can't run this script as it stands, because it doesn't contain the Go files. So, how to add them?

We could create a `txtar` archive of the directory using `txtar-c`, concatenate the result with our original script, and run the result of _that_ with `testscript`. This is straightforward:

```sh
cp test.txtar archive.txtar
txtar-c $DIR >>archive.txtar
testscript archive.txtar
rm archive.txtar
```

Unfortunately, if `DIR` has files containing `txtar` file marker lines, this produces the wrong result. `txtar-c -quote` prepends the necessary `unquote` lines to its archive:

```
unquote expect
-- expect --
> -- input.txt --
> hello world
```

Simple-mindedly prepending our `test.txtar` script to this would produce:

```
exec go test
unquote expect
... 
```

That's no good, because presumably we need the files to be unquoted _before_ running `go test`. So the script needs to go after any `unquote` lines, but _before_ the file data. This is _not_ straightforward, and this shell script is unsatisfactory for any number of reasons (bonus points if you spot all twelve):

```sh
txtar-c -quote $DIR >archive.tmp
# First, extract the leading 'unquote' lines
grep unquote archive.tmp >archive.txtar
# Next, append the script lines
cat test.txtar >>archive.txtar
# Finally, append the remaining file data
grep -v 'unquote' archive.tmp >>archive.txtar
testscript archive.txtar
rm archive.tmp archive.txtar
```

How much nicer it would be if we could simply ask `txtar-c` to include our script file in the appropriate place!

```
txtar-c -script test.txtar -quote $DIR | testscript
```

This makes it very easy and pleasant to use `testscript` to run scripts against some existing set of files, for example in a CI pipeline. A decent value-add for eight extra lines of code, I think.