### PR TITLE
Add link to testscript tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ Included are the following:
 - testenv: information on the current testing environment.
 - testscript: script-based testing based on txtar files
 - txtar: simple text-based file archives for testing.
+
+# Links
+
+- [Test scripts in Go](https://bitfieldconsulting.com/golang/test-scripts)


### PR DESCRIPTION
The linked article is the first in a forthcoming five-part user's guide to `testscript`, based on the content (from _The Power of Go: Tests_) already reviewed by our esteemed maintainers. I hope you'll consider it as a small contribution to the docs, which may help to bring in new users and contributors to the project.