### PR TITLE
testscript: add Params.ContinueOnError

### DIFF
--- a/cmd/testscript/main.go
+++ b/cmd/testscript/main.go
@@ -209,8 +209,9 @@ func (tr *testRunner) run(runDir, filename string) error {
 	}
 
 	p := testscript.Params{
-		Dir:           runDir,
-		UpdateScripts: tr.update,
+		Dir:             runDir,
+		UpdateScripts:   tr.update,
+		ContinueOnError: tr.continueOnError,
 	}
 
 	if _, err := exec.LookPath("go"); err == nil {
@@ -278,8 +279,7 @@ func (tr *testRunner) run(runDir, filename string) error {
 	}
 
 	r := &runT{
-		continueOnError: tr.continueOnError,
-		verbose:         tr.verbose,
+		verbose: tr.verbose,
 	}
 
 	func() {
@@ -347,9 +347,8 @@ func renderFilename(filename string) string {
 
 // runT implements testscript.T and is used in the call to testscript.Run
 type runT struct {
-	verbose         bool
-	continueOnError bool
-	failed          int32
+	verbose bool
+	failed  int32
 }
 
 func (r *runT) Skip(is ...interface{}) {
@@ -372,9 +371,7 @@ func (r *runT) Log(is ...interface{}) {
 
 func (r *runT) FailNow() {
 	atomic.StoreInt32(&r.failed, 1)
-	if !r.continueOnError {
-		panic(failedRun)
-	}
+	panic(failedRun)
 }
 
 func (r *runT) Failed() bool {

--- a/testscript/testdata/testscript_logging.txt
+++ b/testscript/testdata/testscript_logging.txt
@@ -1,0 +1,108 @@
+# non-verbose, non-continue
+! testscript scripts
+cmpenv stdout expect-stdout.txt
+
+# verbose
+! testscript -v scripts
+cmpenv stdout expect-stdout-v.txt
+
+# continue
+! testscript -continue scripts
+cmpenv stdout expect-stdout-c.txt
+
+# verbose, continue
+! testscript -v -continue scripts
+cmpenv stdout expect-stdout-vc.txt
+
+-- scripts/testscript.txt --
+# comment 1
+printargs section1
+
+# comment 2
+printargs section2
+
+# comment 3
+printargs section3
+status 1
+
+# comment 4
+printargs section3
+
+# comment 5
+printargs section5
+status 1
+
+-- expect-stdout.txt --
+# comment 1 (0.000s)
+# comment 2 (0.000s)
+# comment 3 (0.000s)
+> printargs section3
+[stdout]
+["printargs" "section3"]
+> status 1
+[exit status 1]
+FAIL: $$WORK${/}scripts${/}testscript.txt:9: unexpected command failure
+-- expect-stdout-v.txt --
+# comment 1 (0.000s)
+> printargs section1
+[stdout]
+["printargs" "section1"]
+# comment 2 (0.000s)
+> printargs section2
+[stdout]
+["printargs" "section2"]
+# comment 3 (0.000s)
+> printargs section3
+[stdout]
+["printargs" "section3"]
+> status 1
+[exit status 1]
+FAIL: $$WORK${/}scripts${/}testscript.txt:9: unexpected command failure
+-- expect-stdout-c.txt --
+# comment 1 (0.000s)
+# comment 2 (0.000s)
+# comment 3 (0.000s)
+> printargs section3
+[stdout]
+["printargs" "section3"]
+> status 1
+[exit status 1]
+FAIL: $$WORK${/}scripts${/}testscript.txt:9: unexpected command failure
+# comment 4 (0.000s)
+> printargs section3
+[stdout]
+["printargs" "section3"]
+# comment 5 (0.000s)
+> printargs section5
+[stdout]
+["printargs" "section5"]
+> status 1
+[exit status 1]
+FAIL: $$WORK${/}scripts${/}testscript.txt:16: unexpected command failure
+-- expect-stdout-vc.txt --
+# comment 1 (0.000s)
+> printargs section1
+[stdout]
+["printargs" "section1"]
+# comment 2 (0.000s)
+> printargs section2
+[stdout]
+["printargs" "section2"]
+# comment 3 (0.000s)
+> printargs section3
+[stdout]
+["printargs" "section3"]
+> status 1
+[exit status 1]
+FAIL: $$WORK${/}scripts${/}testscript.txt:9: unexpected command failure
+# comment 4 (0.000s)
+> printargs section3
+[stdout]
+["printargs" "section3"]
+# comment 5 (0.000s)
+> printargs section5
+[stdout]
+["printargs" "section5"]
+> status 1
+[exit status 1]
+FAIL: $$WORK${/}scripts${/}testscript.txt:16: unexpected command failure

--- a/testscript/testscript_test.go
+++ b/testscript/testscript_test.go
@@ -59,6 +59,11 @@ func signalCatcher() int {
 }
 
 func TestMain(m *testing.M) {
+	timeSince = func(t time.Time) time.Duration {
+		return 0
+	}
+
+	showVerboseEnv = false
 	os.Exit(RunMain(m, map[string]func() int{
 		"printargs":     printArgs,
 		"fprintargs":    fprintArgs,
@@ -183,12 +188,13 @@ func TestScripts(t *testing.T) {
 				fset := flag.NewFlagSet("testscript", flag.ContinueOnError)
 				fUpdate := fset.Bool("update", false, "update scripts when cmp fails")
 				fExplicitExec := fset.Bool("explicit-exec", false, "require explicit use of exec for commands")
-				fVerbose := fset.Bool("verbose", false, "be verbose with output")
+				fVerbose := fset.Bool("v", false, "be verbose with output")
+				fContinue := fset.Bool("continue", false, "continue on error")
 				if err := fset.Parse(args); err != nil {
 					ts.Fatalf("failed to parse args for testscript: %v", err)
 				}
 				if fset.NArg() != 1 {
-					ts.Fatalf("testscript [-verbose] [-update] [-explicit-exec] <dir>")
+					ts.Fatalf("testscript [-v] [-continue] [-update] [-explicit-exec] <dir>")
 				}
 				dir := fset.Arg(0)
 				t := &fakeT{ts: ts, verbose: *fVerbose}
@@ -208,6 +214,7 @@ func TestScripts(t *testing.T) {
 							"some-param-cmd": func(ts *TestScript, neg bool, args []string) {
 							},
 						},
+						ContinueOnError: *fContinue,
 					})
 				}()
 				ts.stdout = strings.Replace(t.log.String(), ts.workdir, "$WORK", -1)


### PR DESCRIPTION
This fixes a few issues around the existing `testscript -continue` flag. Notably:

- causing `T.Fatal` and `T.FailNow` to return normally meant that some logic inside the testscript package that was expecting the old behaviour would fail to work correctly (for example, a non-existent command would cause a panic)
- the logging logic was erroneously assuming that if we got to the end of a script, all sections had passed therefore we could omit the logged messages.

We fix the above by making "continue on error" a first class part of `testscript.Params`, so the testscript logic actually knows about it.

To test it properly, we need a couple of hacks to make the output predictable. Unfortunately, those hacks are internal only, so it's hard to add similar tests to the `cmd/testscript` command to end-to-end test that, but the existing test should act as sufficient "smoke test" that the continue logic is wired up OK.