### PR TITLE
ci: bump Go versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,23 +11,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.17.x, 1.18.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version:
+        - '1.18.x'
+        - '1.19.x'
+        os:
+        - ubuntu-latest
+        - macos-latest
+        - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
     - name: Install Go
       uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v3
     - name: Test
       run: |
         go test ./...
         go test -race ./...
 
     - name: Tidy
-      if: matrix.os == 'ubuntu-latest' # no need to do this everywhere
+      if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.19.x' # no need to do this everywhere
       run: |
         go mod tidy
 

--- a/cmd/txtar-c/savedir.go
+++ b/cmd/txtar-c/savedir.go
@@ -10,7 +10,6 @@
 //
 // See https://godoc.org/github.com/rogpeppe/go-internal/txtar for details of the format
 // and how to parse a txtar file.
-//
 package main
 
 import (

--- a/cmd/txtar-goproxy/main.go
+++ b/cmd/txtar-goproxy/main.go
@@ -8,9 +8,9 @@
 // This allows interactive experimentation with the set of proxied modules.
 // For example:
 //
-// 	cd cmd/go
-// 	go test -proxy=localhost:1234 &
-// 	export GOPROXY=http://localhost:1234/mod
+//	cd cmd/go
+//	go test -proxy=localhost:1234 &
+//	export GOPROXY=http://localhost:1234/mod
 //
 // and then run go commands as usual.
 package main

--- a/cmd/txtar-x/extract.go
+++ b/cmd/txtar-x/extract.go
@@ -10,7 +10,6 @@
 //
 // See https://godoc.org/github.com/rogpeppe/go-internal/txtar for details of the format
 // and how to parse a txtar file.
-//
 package main
 
 import (

--- a/fmtsort/sort.go
+++ b/fmtsort/sort.go
@@ -36,19 +36,18 @@ func (o *SortedMap) Swap(i, j int) {
 //
 // The ordering rules are more general than with Go's < operator:
 //
-//  - when applicable, nil compares low
-//  - ints, floats, and strings order by <
-//  - NaN compares less than non-NaN floats
-//  - bool compares false before true
-//  - complex compares real, then imag
-//  - pointers compare by machine address
-//  - channel values compare by machine address
-//  - structs compare each field in turn
-//  - arrays compare each element in turn.
-//    Otherwise identical arrays compare by length.
-//  - interface values compare first by reflect.Type describing the concrete type
-//    and then by concrete value as described in the previous rules.
-//
+//   - when applicable, nil compares low
+//   - ints, floats, and strings order by <
+//   - NaN compares less than non-NaN floats
+//   - bool compares false before true
+//   - complex compares real, then imag
+//   - pointers compare by machine address
+//   - channel values compare by machine address
+//   - structs compare each field in turn
+//   - arrays compare each element in turn.
+//     Otherwise identical arrays compare by length.
+//   - interface values compare first by reflect.Type describing the concrete type
+//     and then by concrete value as described in the previous rules.
 func Sort(mapValue reflect.Value) *SortedMap {
 	if mapValue.Type().Kind() != reflect.Map {
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/rogpeppe/go-internal
 
-go 1.17
+go 1.18
 
 require github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e

--- a/imports/build.go
+++ b/imports/build.go
@@ -32,7 +32,6 @@ var slashslash = []byte("//")
 // the purpose of satisfying build tags, in order to estimate
 // (conservatively) whether a file could ever possibly be used
 // in any build.
-//
 func ShouldBuild(content []byte, tags map[string]bool) bool {
 	// Pass 1. Identify leading run of // comments and blank lines,
 	// which must be followed by a blank line.
@@ -96,7 +95,6 @@ func ShouldBuild(content []byte, tags map[string]bool) bool {
 //	tag (if tags[tag] is true)
 //	!tag (if tags[tag] is false)
 //	a comma-separated list of any of these
-//
 func matchTags(name string, tags map[string]bool) bool {
 	if name == "" {
 		return false
@@ -145,12 +143,12 @@ func matchTag(name string, tags map[string]bool, want bool) bool {
 // suffix which does not match the current system.
 // The recognized name formats are:
 //
-//     name_$(GOOS).*
-//     name_$(GOARCH).*
-//     name_$(GOOS)_$(GOARCH).*
-//     name_$(GOOS)_test.*
-//     name_$(GOARCH)_test.*
-//     name_$(GOOS)_$(GOARCH)_test.*
+//	name_$(GOOS).*
+//	name_$(GOARCH).*
+//	name_$(GOOS)_$(GOARCH).*
+//	name_$(GOOS)_test.*
+//	name_$(GOARCH)_test.*
+//	name_$(GOOS)_$(GOARCH)_test.*
 //
 // An exception: if GOOS=android, then files with GOOS=linux are also matched.
 //

--- a/internal/syscall/windows/registry/key.go
+++ b/internal/syscall/windows/registry/key.go
@@ -23,7 +23,6 @@
 //
 // NOTE: This package is a copy of golang.org/x/sys/windows/registry
 // with KeyInfo.ModTime removed to prevent dependency cycles.
-//
 package registry
 
 import (

--- a/modfile/read.go
+++ b/modfile/read.go
@@ -244,7 +244,6 @@ func (x *Line) Span() (start, end Position) {
 //		"x"
 //		"y"
 //	)
-//
 type LineBlock struct {
 	Comments
 	Start  Position

--- a/testenv/testenv.go
+++ b/testenv/testenv.go
@@ -30,7 +30,7 @@ func Builder() string {
 	return os.Getenv("GO_BUILDER_NAME")
 }
 
-// HasGoBuild reports whether the current system can build programs with ``go build''
+// HasGoBuild reports whether the current system can build programs with “go build”
 // and then run them with os.StartProcess or exec.Command.
 func HasGoBuild() bool {
 	if os.Getenv("GO_GCFLAGS") != "" {
@@ -51,7 +51,7 @@ func HasGoBuild() bool {
 	return true
 }
 
-// MustHaveGoBuild checks that the current system can build programs with ``go build''
+// MustHaveGoBuild checks that the current system can build programs with “go build”
 // and then run them with os.StartProcess or exec.Command.
 // If not, MustHaveGoBuild calls t.Skip with an explanation.
 func MustHaveGoBuild(t testing.TB) {
@@ -63,13 +63,13 @@ func MustHaveGoBuild(t testing.TB) {
 	}
 }
 
-// HasGoRun reports whether the current system can run programs with ``go run.''
+// HasGoRun reports whether the current system can run programs with “go run.”
 func HasGoRun() bool {
 	// For now, having go run and having go build are the same.
 	return HasGoBuild()
 }
 
-// MustHaveGoRun checks that the current system can run programs with ``go run.''
+// MustHaveGoRun checks that the current system can run programs with “go run.”
 // If not, MustHaveGoRun calls t.Skip with an explanation.
 func MustHaveGoRun(t testing.TB) {
 	if !HasGoRun() {


### PR DESCRIPTION
I noticed CI was still using Go 1.17 and 1.18.