### PR TITLE
txtar: alias types to x/tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/rogpeppe/go-internal
 
 go 1.19
 
-require golang.org/x/mod v0.9.0
+require (
+	golang.org/x/mod v0.9.0
+	golang.org/x/tools v0.1.12
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
 golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
+golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=

--- a/txtar/archive.go
+++ b/txtar/archive.go
@@ -40,32 +40,22 @@ import (
 	"path/filepath"
 	"strings"
 	"unicode/utf8"
+
+	"golang.org/x/tools/txtar"
 )
 
 // An Archive is a collection of files.
-type Archive struct {
-	Comment []byte
-	Files   []File
-}
+type Archive = txtar.Archive
 
 // A File is a single file in an archive.
-type File struct {
-	Name string // name of file ("foo/bar.txt")
-	Data []byte // text content of file
-}
+type File = txtar.File
 
 // Format returns the serialized form of an Archive.
 // It is assumed that the Archive data structure is well-formed:
 // a.Comment and all a.File[i].Data contain no file marker lines,
 // and all a.File[i].Name is non-empty.
 func Format(a *Archive) []byte {
-	var buf bytes.Buffer
-	buf.Write(fixNL(a.Comment))
-	for _, f := range a.Files {
-		fmt.Fprintf(&buf, "-- %s --\n", f.Name)
-		buf.Write(fixNL(f.Data))
-	}
-	return buf.Bytes()
+	return txtar.Format(a)
 }
 
 // ParseFile parses the named file as an archive.
@@ -79,6 +69,9 @@ func ParseFile(file string) (*Archive, error) {
 
 // Parse parses the serialized form of an Archive.
 // The returned Archive holds slices of data.
+//
+// TODO use golang.org/x/tools/txtar.Parse when https://github.com/golang/go/issues/59264
+// is fixed.
 func Parse(data []byte) *Archive {
 	a := new(Archive)
 	var name string

--- a/txtar/archive_test.go
+++ b/txtar/archive_test.go
@@ -44,7 +44,7 @@ hello world`,
 	},
 	// Test CRLF input
 	{
-		name: "basic",
+		name: "basicCRLF",
 		text: "blah\r\n-- hello --\r\nhello\r\n",
 		parsed: &Archive{
 			Comment: []byte("blah\r\n"),


### PR DESCRIPTION
Although we can't quite use the x/tools/txtar implementation in its entirety (https://github.com/golang/go/issues/59264 needs to be fixed first, and we implement some other functions that x/tools/txtar doesn't (yet?) have, we can at least alias its types, which makes it possible to work with other packages that use those types.