### PR TITLE
testscript: fix "signal: killed" exec errors on MacOS by doing a full copy of binaries

### DIFF
--- a/testscript/exe.go
+++ b/testscript/exe.go
@@ -121,8 +121,9 @@ func RunMain(m TestingM, commands map[string]func() int) (exitCode int) {
 // unix-like setups. Note that "go test" also places test binaries in the
 // system's temporary directory, like we do. We don't use hard links on Windows,
 // as that can lead to "access denied" errors when removing.
+// We also currently don't use hard links on macOS, see issue #200.
 func copyBinary(from, to string) error {
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
 		if err := os.Link(from, to); err == nil {
 			return nil
 		}


### PR DESCRIPTION
By doing a full copy and not a hard link of the binaries.

This is the fall back used already for Windows.

This is tested OK to remove unexpected test failures with error output similar to:

```
[signal: killed]
FAIL: testscripts/myecho.txt:1: unexpected command failure
```

See #200