### PR TITLE
testscript: handle the "fail now!" panic in cmdWait

### DIFF
--- a/testscript/cmd.go
+++ b/testscript/cmd.go
@@ -452,6 +452,11 @@ func (ts *TestScript) cmdUNIX2DOS(neg bool, args []string) {
 
 // Tait waits for background commands to exit, setting stderr and stdout to their result.
 func (ts *TestScript) cmdWait(neg bool, args []string) {
+	defer catchFailNow(func() {
+		// There's been a failure in setup; fail immediately regardless
+		// of the ContinueOnError flag.
+		ts.t.FailNow()
+	})
 	if len(args) > 1 {
 		ts.Fatalf("usage: wait [name]")
 	}


### PR DESCRIPTION
Closes #228
