### PR TITLE
bump to Go 1.21, drop Go 1.19, propagate GORACE in testscript

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-        - '1.19.x'
         - '1.20.x'
+        - '1.21.x'
         os:
         - ubuntu-latest
         - macos-latest
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install Go
       uses: actions/setup-go@v4
       with:
@@ -33,7 +33,7 @@ jobs:
         go test -race ./...
 
     - name: Tidy
-      if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.20.x' # no need to do this everywhere
+      if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.21.x' # no need to do this everywhere
       run: |
         go mod tidy
 

--- a/cmd/testscript/testdata/noproxy.txt
+++ b/cmd/testscript/testdata/noproxy.txt
@@ -1,10 +1,12 @@
 # With no .gomodproxy supporting files, we use the GOPROXY from
 # the environment.
+# Note that Go 1.21 started quoting with single quotes in "go env",
+# where older versions used double quotes.
 env GOPROXY=0.1.2.3
 unquote file.txt
 testscript -v file.txt
 
 -- file.txt --
 >go env
->[!windows] stdout '^GOPROXY="0.1.2.3"$'
+>[!windows] stdout '^GOPROXY=[''"]0.1.2.3[''"]$'
 >[windows] stdout '^set GOPROXY=0.1.2.3$'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rogpeppe/go-internal
 
-go 1.19
+go 1.20
 
 require (
 	golang.org/x/mod v0.9.0

--- a/gotooltest/testdata/cover.txt
+++ b/gotooltest/testdata/cover.txt
@@ -13,12 +13,9 @@ stdout 'PASS'
 # Then, a 'go test' run with -coverprofile.
 # The total coverage after merging profiles should end up being 100%.
 # Marking all printlns as covered requires all edge cases to work well.
-# Go 1.20 learned to produce and merge multiple coverage profiles,
-# so versions before then report a shallow 0% coverage.
 go test -vet=off -coverprofile=cover.out -v
 stdout 'PASS'
-[go1.20] stdout 'coverage: 100\.0%'
-[!go1.20] stdout 'coverage: 0\.0%'
+stdout 'coverage: 100\.0%'
 ! stdout 'malformed coverage' # written by "go test" if cover.out is invalid
 exists cover.out
 

--- a/testscript/testdata/pty.txt
+++ b/testscript/testdata/pty.txt
@@ -1,5 +1,5 @@
 [!linux] [!darwin] skip
-[darwin] [go1.20] skip # https://go.dev/issue/61779
+[darwin] skip # https://go.dev/issue/61779
 
 ttyin secretwords.txt
 terminalprompt

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -16,7 +16,6 @@ import (
 	"go/build"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -262,14 +261,14 @@ func RunT(t T, p Params) {
 	}
 	testTempDir := p.WorkdirRoot
 	if testTempDir == "" {
-		testTempDir, err = ioutil.TempDir(os.Getenv("GOTMPDIR"), "go-test-script")
+		testTempDir, err = os.MkdirTemp(os.Getenv("GOTMPDIR"), "go-test-script")
 		if err != nil {
 			t.Fatal(err)
 		}
 	} else {
 		p.TestWork = true
 	}
-	// The temp dir returned by ioutil.TempDir might be a sym linked dir (default
+	// The temp dir returned by os.MkdirTemp might be a sym linked dir (default
 	// behaviour in macOS). That could mess up matching that includes $WORK if,
 	// for example, an external program outputs resolved paths. Evaluating the
 	// dir here will ensure consistency.
@@ -780,7 +779,7 @@ func (ts *TestScript) applyScriptUpdates() {
 			panic("script update file not found")
 		}
 	}
-	if err := ioutil.WriteFile(ts.file, txtar.Format(ts.archive), 0o666); err != nil {
+	if err := os.WriteFile(ts.file, txtar.Format(ts.archive), 0o666); err != nil {
 		ts.t.Fatal("cannot update script: ", err)
 	}
 	ts.Logf("%s updated", ts.file)
@@ -1174,7 +1173,7 @@ func (ts *TestScript) ReadFile(file string) string {
 		return ts.ttyout
 	default:
 		file = ts.MkAbs(file)
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		ts.Check(err)
 		return string(data)
 	}


### PR DESCRIPTION
(see commit messages - please do not squash)

