### PR TITLE
testscript: fix ptyName() returning /dev/pts/4294967296 on s390x

### DIFF
--- a/testscript/internal/pty/pty_linux.go
+++ b/testscript/internal/pty/pty_linux.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ptyName(f *os.File) (string, error) {
-	var out uint
+	var out uint32
 	err := ioctl(f, "TIOCGPTN", syscall.TIOCGPTN, uintptr(unsafe.Pointer(&out)))
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Use uint32 instead of uint (64-bit in Go on s390x) to store the return value of the TIOCGPTN syscall.  This is to avoid the 32-bit value from being stored into a 64-bit buffer and get left-shifted by 32 when dereferencing, turning what should be e.g. /dev/pts/1 to /dev/pts/4294967296 on big-endian architectures such as s390x.

Special thanks to the explanation and a similar bug fix provided at https://github.com/containerd/console/pull/51

Fixes the following TestScripts/pty error on s390x:

```
=== NAME  TestScripts/pty
    testscript.go:558: > [!linux] [!darwin] skip
        > [darwin] skip # https://go.dev/issue/61779
        > ttyin secretwords.txt
        > terminalprompt
        [failed to open TTY: open /dev/pts/21474836480: no such file or directory]
        FAIL: testdata/pty.txt:5: unexpected command failure
```

discovered by Debian autopkgtest CI for golang-github-rogpeppe-go-internal/1.12.0-1;
see log at <https://ci.debian.net/packages/g/golang-github-rogpeppe-go-internal/testing/s390x/43022768/#L3047>

(Hmm... I guess /dev/pts/21474836480 should have been /dev/pts/5, as `5 << 32 = 21474836480`.)

Special thanks also to @kapouer for providing an interim workaround in golang-github-rogpeppe-go-internal/1.12.0-2 for Debian as 1.12.0-1 was blocked from entering "trixie (testing)" for 16 days due to test error on s390x.