### PR TITLE
testscript: Add Chdir method to change directory

### DIFF
--- a/testscript/cmd.go
+++ b/testscript/cmd.go
@@ -62,18 +62,11 @@ func (ts *TestScript) cmdCd(neg bool, args []string) {
 	}
 
 	dir := args[0]
-	if !filepath.IsAbs(dir) {
-		dir = filepath.Join(ts.cd, dir)
-	}
-	info, err := os.Stat(dir)
+	err := ts.Chdir(dir)
 	if os.IsNotExist(err) {
 		ts.Fatalf("directory %s does not exist", dir)
 	}
 	ts.Check(err)
-	if !info.IsDir() {
-		ts.Fatalf("%s is not a directory", dir)
-	}
-	ts.cd = dir
 	ts.Logf("%s\n", ts.cd)
 }
 

--- a/testscript/testdata/custom_cd.txt
+++ b/testscript/testdata/custom_cd.txt
@@ -1,0 +1,7 @@
+# Verify that a custom command can chdir.
+
+mkChdir foo
+exists $WORK/foo
+
+# Current directory is not $WORK.
+! exists foo

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -1043,6 +1043,24 @@ func (ts *TestScript) BackgroundCmds() []*exec.Cmd {
 	return cmds
 }
 
+// Chdir changes the current directory of the script.
+// The path may be relative to the current directory.
+func (ts *TestScript) Chdir(dir string) error {
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(ts.cd, dir)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", dir)
+	}
+
+	ts.cd = dir
+	return nil
+}
+
 // waitOrStop waits for the already-started command cmd by calling its Wait method.
 //
 // If cmd does not return before ctx is done, waitOrStop sends it an interrupt

--- a/testscript/testscript_test.go
+++ b/testscript/testscript_test.go
@@ -270,6 +270,27 @@ func TestScripts(t *testing.T) {
 				}
 			},
 			"echoandexit": echoandexit,
+			"mkChdir": func(ts *TestScript, neg bool, args []string) {
+				if neg {
+					ts.Fatalf("unsupported: ! mkChdir")
+				}
+				if len(args) != 1 {
+					ts.Fatalf("usage: mkChdir dir")
+				}
+
+				dir := args[0]
+				if !filepath.IsAbs(dir) {
+					dir = ts.MkAbs(dir)
+				}
+
+				if err := os.MkdirAll(dir, 0o777); err != nil {
+					ts.Fatalf("cannot create dir: %v", err)
+				}
+
+				if err := ts.Chdir(dir); err != nil {
+					ts.Fatalf("cannot chdir: %v", err)
+				}
+			},
 		},
 		Setup: func(env *Env) error {
 			infos, err := ioutil.ReadDir(env.WorkDir)


### PR DESCRIPTION
It is not currently possible for a custom testscript command
to change the working directory of that script run.
`TestScript.Exec` runs the command in a subprocess,
so one cannot do `ts.Exec("cd", dir)`.

This change adds a `Chdir` method to `TestScript`
that allows changing the working directory of the script.
The implementation is the same as the "cd" command,
which now relies on `Chdir`.

The availability of this function matches similar functionality in the
[`State.Chdir` method of rsc.io/script][1].
(I ported some tests from rsc.io/script to testscript.)

  [1]: https://pkg.go.dev/rsc.io/script#State.Chdir
