### PR TITLE
all: Move away from ioutil

### DIFF
--- a/cmd/testscript/main.go
+++ b/cmd/testscript/main.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,7 +72,7 @@ func mainerr() (retErr error) {
 		return err
 	}
 
-	td, err := ioutil.TempDir("", "testscript")
+	td, err := os.MkdirTemp("", "testscript")
 	if err != nil {
 		return fmt.Errorf("unable to create temp dir: %v", err)
 	}
@@ -171,7 +171,7 @@ func (tr *testRunner) run(runDir, filename string) error {
 	}
 
 	if filename == "-" {
-		byts, err := ioutil.ReadAll(os.Stdin)
+		byts, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("failed to read from stdin: %v", err)
 		}
@@ -204,7 +204,7 @@ func (tr *testRunner) run(runDir, filename string) error {
 
 	scriptFile := filepath.Join(runDir, "script.txtar")
 
-	if err := ioutil.WriteFile(scriptFile, txtar.Format(&script), 0o666); err != nil {
+	if err := os.WriteFile(scriptFile, txtar.Format(&script), 0o666); err != nil {
 		return fmt.Errorf("failed to write script for %v: %v", renderFilename(filename), err)
 	}
 
@@ -309,7 +309,7 @@ func (tr *testRunner) run(runDir, filename string) error {
 		// Parse the (potentially) updated scriptFile as an archive, then merge
 		// with the original archive, retaining order.  Then write the archive
 		// back to the source file
-		source, err := ioutil.ReadFile(scriptFile)
+		source, err := os.ReadFile(scriptFile)
 		if err != nil {
 			return fmt.Errorf("failed to read from script file %v for -update: %v", scriptFile, err)
 		}
@@ -323,7 +323,7 @@ func (tr *testRunner) run(runDir, filename string) error {
 				ar.Files[i] = newF
 			}
 		}
-		if err := ioutil.WriteFile(filename, txtar.Format(ar), 0o666); err != nil {
+		if err := os.WriteFile(filename, txtar.Format(ar), 0o666); err != nil {
 			return fmt.Errorf("failed to write script back to %v for -update: %v", renderFilename(filename), err)
 		}
 	}

--- a/dirhash/hash_test.go
+++ b/dirhash/hash_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,7 +28,7 @@ func htop(k string, s string) string {
 func TestHash1(t *testing.T) {
 	files := []string{"xyz", "abc"}
 	open := func(name string) (io.ReadCloser, error) {
-		return ioutil.NopCloser(strings.NewReader("data for " + name)), nil
+		return io.NopCloser(strings.NewReader("data for " + name)), nil
 	}
 	want := htop("h1", fmt.Sprintf("%s  %s\n%s  %s\n", h("data for abc"), "abc", h("data for xyz"), "xyz"))
 	out, err := Hash1(files, open)
@@ -47,15 +46,15 @@ func TestHash1(t *testing.T) {
 }
 
 func TestHashDir(t *testing.T) {
-	dir, err := ioutil.TempDir("", "dirhash-test-")
+	dir, err := os.MkdirTemp("", "dirhash-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
-	if err := ioutil.WriteFile(filepath.Join(dir, "xyz"), []byte("data for xyz"), 0o666); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "xyz"), []byte("data for xyz"), 0o666); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, "abc"), []byte("data for abc"), 0o666); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "abc"), []byte("data for abc"), 0o666); err != nil {
 		t.Fatal(err)
 	}
 	want := htop("h1", fmt.Sprintf("%s  %s\n%s  %s\n", h("data for abc"), "prefix/abc", h("data for xyz"), "prefix/xyz"))
@@ -69,7 +68,7 @@ func TestHashDir(t *testing.T) {
 }
 
 func TestHashZip(t *testing.T) {
-	f, err := ioutil.TempFile("", "dirhash-test-")
+	f, err := os.CreateTemp("", "dirhash-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,21 +104,21 @@ func TestHashZip(t *testing.T) {
 }
 
 func TestDirFiles(t *testing.T) {
-	dir, err := ioutil.TempDir("", "dirfiles-test-")
+	dir, err := os.MkdirTemp("", "dirfiles-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
-	if err := ioutil.WriteFile(filepath.Join(dir, "xyz"), []byte("data for xyz"), 0o666); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "xyz"), []byte("data for xyz"), 0o666); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, "abc"), []byte("data for abc"), 0o666); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "abc"), []byte("data for abc"), 0o666); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, "subdir", "xyz"), []byte("data for subdir xyz"), 0o666); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "subdir", "xyz"), []byte("data for subdir xyz"), 0o666); err != nil {
 		t.Fatal(err)
 	}
 	prefix := "foo/bar@v2.3.4"

--- a/imports/scan.go
+++ b/imports/scan.go
@@ -6,7 +6,6 @@ package imports
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -15,14 +14,14 @@ import (
 )
 
 func ScanDir(dir string, tags map[string]bool) ([]string, []string, error) {
-	infos, err := ioutil.ReadDir(dir)
+	infos, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, nil, err
 	}
 	var files []string
 	for _, info := range infos {
 		name := info.Name()
-		if info.Mode().IsRegular() && !strings.HasPrefix(name, "_") && strings.HasSuffix(name, ".go") && MatchFile(name, tags) {
+		if info.Type().IsRegular() && !strings.HasPrefix(name, "_") && strings.HasSuffix(name, ".go") && MatchFile(name, tags) {
 			files = append(files, filepath.Join(dir, name))
 		}
 	}

--- a/renameio/renameio.go
+++ b/renameio/renameio.go
@@ -10,7 +10,6 @@ package renameio
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -35,7 +34,7 @@ func WriteFile(filename string, data []byte) (err error) {
 // WriteToFile is a variant of WriteFile that accepts the data as an io.Reader
 // instead of a slice.
 func WriteToFile(filename string, data io.Reader) (err error) {
-	f, err := ioutil.TempFile(filepath.Dir(filename), filepath.Base(filename)+patternSuffix)
+	f, err := os.CreateTemp(filepath.Dir(filename), filepath.Base(filename)+patternSuffix)
 	if err != nil {
 		return err
 	}

--- a/testenv/testenv_windows.go
+++ b/testenv/testenv_windows.go
@@ -5,7 +5,6 @@
 package testenv
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -16,7 +15,7 @@ var symlinkOnce sync.Once
 var winSymlinkErr error
 
 func initWinHasSymlink() {
-	tmpdir, err := ioutil.TempDir("", "symtest")
+	tmpdir, err := os.MkdirTemp("", "symtest")
 	if err != nil {
 		panic("failed to create temp directory: " + err.Error())
 	}

--- a/testscript/cmd.go
+++ b/testscript/cmd.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -120,7 +119,7 @@ func (ts *TestScript) doCmdCmp(neg bool, args []string, env bool) {
 	text1 := ts.ReadFile(name1)
 
 	absName2 := ts.MkAbs(name2)
-	data, err := ioutil.ReadFile(absName2)
+	data, err := os.ReadFile(absName2)
 	ts.Check(err)
 	text2 := string(data)
 	if env {
@@ -191,14 +190,14 @@ func (ts *TestScript) cmdCp(neg bool, args []string) {
 			info, err := os.Stat(src)
 			ts.Check(err)
 			mode = info.Mode() & 0o777
-			data, err = ioutil.ReadFile(src)
+			data, err = os.ReadFile(src)
 			ts.Check(err)
 		}
 		targ := dst
 		if dstDir {
 			targ = filepath.Join(dst, filepath.Base(src))
 		}
-		ts.Check(ioutil.WriteFile(targ, data, mode))
+		ts.Check(os.WriteFile(targ, data, mode))
 	}
 }
 
@@ -337,11 +336,11 @@ func (ts *TestScript) cmdUnquote(neg bool, args []string) {
 	}
 	for _, arg := range args {
 		file := ts.MkAbs(arg)
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		ts.Check(err)
 		data, err = txtar.Unquote(data)
 		ts.Check(err)
-		err = ioutil.WriteFile(file, data, 0o666)
+		err = os.WriteFile(file, data, 0o666)
 		ts.Check(err)
 	}
 }
@@ -482,11 +481,11 @@ func (ts *TestScript) cmdUNIX2DOS(neg bool, args []string) {
 	}
 	for _, arg := range args {
 		filename := ts.MkAbs(arg)
-		data, err := ioutil.ReadFile(filename)
+		data, err := os.ReadFile(filename)
 		ts.Check(err)
 		dosData, err := unix2DOS(data)
 		ts.Check(err)
-		if err := ioutil.WriteFile(filename, dosData, 0o666); err != nil {
+		if err := os.WriteFile(filename, dosData, 0o666); err != nil {
 			ts.Fatalf("%s: %v", filename, err)
 		}
 	}
@@ -632,7 +631,7 @@ func scriptMatch(ts *TestScript, neg bool, args []string, text, name string) {
 	isGrep := name == "grep"
 	if isGrep {
 		name = args[1] // for error messages
-		data, err := ioutil.ReadFile(ts.MkAbs(args[1]))
+		data, err := os.ReadFile(ts.MkAbs(args[1]))
 		ts.Check(err)
 		text = string(data)
 	}

--- a/testscript/exe.go
+++ b/testscript/exe.go
@@ -6,7 +6,6 @@ package testscript
 
 import (
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -56,7 +55,7 @@ func RunMain(m TestingM, commands map[string]func() int) (exitCode int) {
 		// test binary by "go test".
 
 		// Set up all commands in a directory, added in $PATH.
-		tmpdir, err := ioutil.TempDir("", "testscript-main")
+		tmpdir, err := os.MkdirTemp("", "testscript-main")
 		if err != nil {
 			log.Printf("could not set up temporary directory: %v", err)
 			return 2

--- a/testscript/testscript_test.go
+++ b/testscript/testscript_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -49,7 +48,7 @@ func signalCatcher() int {
 	signal.Notify(c, os.Interrupt)
 	// Create a file so that the test can know that
 	// we will catch the signal.
-	if err := ioutil.WriteFile("catchsignal", nil, 0o666); err != nil {
+	if err := os.WriteFile("catchsignal", nil, 0o666); err != nil {
 		fmt.Println(err)
 		return 1
 	}
@@ -90,16 +89,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestCRLFInput(t *testing.T) {
-	td, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed to create TempDir: %v", err)
-	}
-	defer func() {
-		os.RemoveAll(td)
-	}()
+	td := t.TempDir()
 	tf := filepath.Join(td, "script.txt")
 	contents := []byte("exists output.txt\r\n-- output.txt --\r\noutput contents")
-	if err := ioutil.WriteFile(tf, contents, 0o644); err != nil {
+	if err := os.WriteFile(tf, contents, 0o644); err != nil {
 		t.Fatalf("failed to write to %v: %v", tf, err)
 	}
 	t.Run("_", func(t *testing.T) {
@@ -272,7 +265,7 @@ func TestScripts(t *testing.T) {
 			"echoandexit": echoandexit,
 		},
 		Setup: func(env *Env) error {
-			infos, err := ioutil.ReadDir(env.WorkDir)
+			infos, err := os.ReadDir(env.WorkDir)
 			if err != nil {
 				return fmt.Errorf("cannot read workdir: %v", err)
 			}
@@ -350,11 +343,7 @@ func TestTestwork(t *testing.T) {
 
 // TestWorkdirRoot tests that a non zero value in Params.WorkdirRoot is honoured
 func TestWorkdirRoot(t *testing.T) {
-	td, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 	params := Params{
 		Dir:         filepath.Join("testdata", "nothing"),
 		WorkdirRoot: td,

--- a/txtar/archive.go
+++ b/txtar/archive.go
@@ -35,7 +35,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,7 +59,7 @@ func Format(a *Archive) []byte {
 
 // ParseFile parses the named file as an archive.
 func ParseFile(file string) (*Archive, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/txtar/archive_test.go
+++ b/txtar/archive_test.go
@@ -7,8 +7,6 @@ package txtar
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"reflect"
 	"testing"
 )
@@ -81,11 +79,7 @@ func shortArchive(a *Archive) string {
 }
 
 func TestWrite(t *testing.T) {
-	td, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	good := &Archive{Files: []File{File{Name: "good.txt"}}}
 	if err := Write(good, td); err != nil {


### PR DESCRIPTION
It's been a while since io/ioutil has been deprecated.
Go 1.22 was just released, and the go.mod specifies 'go 1.20'.
This should be safe to remove at this point.

The change was largely automated, minus the `t.TempDir()` calls inside
test files, which was done manually.