### PR TITLE
testscript: Expose Environ() to custom commands

### DIFF
--- a/testscript/testdata/environ.txt
+++ b/testscript/testdata/environ.txt
@@ -1,0 +1,8 @@
+env FOO_A=1 FOO_B=2 FOO_C=3
+printEnvPrefix FOO_
+cmp stdout want.txt
+
+-- want.txt --
+FOO_A=1
+FOO_B=2
+FOO_C=3

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -959,7 +959,7 @@ func (ts *TestScript) exec(command string, args ...string) (stdout, stderr strin
 		return "", "", err
 	}
 	cmd.Dir = ts.cd
-	cmd.Env = append(ts.env, "PWD="+ts.cd)
+	cmd.Env = append(ts.Environ(), "PWD="+ts.cd)
 	cmd.Stdin = strings.NewReader(ts.stdin)
 	var stdoutBuf, stderrBuf strings.Builder
 	cmd.Stdout = &stdoutBuf
@@ -1012,7 +1012,7 @@ func (ts *TestScript) execBackground(command string, args ...string) (*exec.Cmd,
 		return nil, err
 	}
 	cmd.Dir = ts.cd
-	cmd.Env = append(ts.env, "PWD="+ts.cd)
+	cmd.Env = append(ts.Environ(), "PWD="+ts.cd)
 	var stdoutBuf, stderrBuf strings.Builder
 	cmd.Stdin = strings.NewReader(ts.stdin)
 	cmd.Stdout = &stdoutBuf
@@ -1220,6 +1220,14 @@ func (ts *TestScript) Setenv(key, value string) {
 // Getenv gets the value of the environment variable named by the key.
 func (ts *TestScript) Getenv(key string) string {
 	return ts.envMap[envvarname(key)]
+}
+
+// Environ returns a copy of environment variables set on the TestScript
+// as a series of key=value strings.
+func (ts *TestScript) Environ() []string {
+	env := make([]string, len(ts.env))
+	copy(env, ts.env)
+	return env
 }
 
 // parse parses a single line as a list of space-separated arguments

--- a/testscript/testscript_test.go
+++ b/testscript/testscript_test.go
@@ -284,6 +284,19 @@ func TestScripts(t *testing.T) {
 					ts.Fatalf("cannot chdir: %v", err)
 				}
 			},
+			"printEnvPrefix": func(ts *TestScript, neg bool, args []string) {
+				if neg || len(args) != 1 {
+					ts.Fatalf("usage: printEnvPrefix <prefix>")
+				}
+
+				w := ts.Stdout()
+				prefix := args[0]
+				for _, kv := range ts.Environ() {
+					if strings.HasPrefix(kv, prefix) {
+						fmt.Fprintln(w, kv)
+					}
+				}
+			},
 		},
 		Setup: func(env *Env) error {
 			infos, err := os.ReadDir(env.WorkDir)


### PR DESCRIPTION
This adds an Environ method to TestScript
that looks and acts similarly to os.Environ.

This gives further visibility into the test script state
to custom command implementations,
allowing them to implement functionality that is otherwise limited
only to the built-in commands.

For example, combining this and MkAbs, a custom command can use os/exec
to run a command with the same environment as the test script,
with different behavior than the built-in TestScript.Exec method.
