### PR TITLE
all: Add Go 1.22, drop Go 1.20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-        - '1.20.x'
         - '1.21.x'
+        - '1.22.x'
         os:
         - ubuntu-latest
         - macos-latest
@@ -33,7 +33,7 @@ jobs:
         go test -race ./...
 
     - name: Tidy
-      if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.21.x' # no need to do this everywhere
+      if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.22.x' # no need to do this everywhere
       run: |
         go mod tidy
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rogpeppe/go-internal
 
-go 1.20
+go 1.21
 
 require (
 	golang.org/x/mod v0.9.0


### PR DESCRIPTION
Switches CI to run against Go 1.21 and 1.22,
and bumps the minimum required Go version to 1.21.

Dropping 1.20 isn't strictly necessary;
this is just matching prior upgrades.
It can be added back if the maintainers prefer.
