### PR TITLE
update dependencies and rely on Go 1.21 APIs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Install Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
         cache: false # our tests are quick enough

--- a/cmd/testscript/testdata/noproxy.txt
+++ b/cmd/testscript/testdata/noproxy.txt
@@ -1,12 +1,10 @@
 # With no .gomodproxy supporting files, we use the GOPROXY from
 # the environment.
-# Note that Go 1.21 started quoting with single quotes in "go env",
-# where older versions used double quotes.
 env GOPROXY=0.1.2.3
 unquote file.txt
 testscript -v file.txt
 
 -- file.txt --
 >go env
->[!windows] stdout '^GOPROXY=[''"]0.1.2.3[''"]$'
+>[!windows] stdout '^GOPROXY=''0.1.2.3''$'
 >[windows] stdout '^set GOPROXY=0.1.2.3$'

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/rogpeppe/go-internal
 go 1.21
 
 require (
-	golang.org/x/mod v0.9.0
-	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
-	golang.org/x/tools v0.1.12
+	golang.org/x/mod v0.18.0
+	golang.org/x/sys v0.21.0
+	golang.org/x/tools v0.22.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
-golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
-golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
-golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
-golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+golang.org/x/mod v0.18.0 h1:5+9lSbEzPSdWkH32vYPBwEpX8KwDbM52Ud9xBUvNlb0=
+golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/tools v0.22.0 h1:gqSGLZqv+AI9lIQzniJ0nZDRG5GBPsSi+DRNHWNz6yA=
+golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -754,15 +754,8 @@ func (ts *TestScript) cmdSuggestions(name string) []string {
 		return nil
 	}
 	// deduplicate candidates
-	// TODO: Use slices.Compact (and maybe slices.Sort) once we can use Go 1.21
-	sort.Strings(candidates)
-	out := candidates[:1]
-	for _, c := range candidates[1:] {
-		if out[len(out)-1] == c {
-			out = append(out, c)
-		}
-	}
-	return out
+	slices.Sort(candidates)
+	return slices.Compact(candidates)
 }
 
 func (ts *TestScript) applyScriptUpdates() {


### PR DESCRIPTION
(see commit message)

