### PR TITLE
cmd/testscript: remove redundant use of Failed

### DIFF
--- a/cmd/testscript/main.go
+++ b/cmd/testscript/main.go
@@ -13,7 +13,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync/atomic"
 
 	"github.com/rogpeppe/go-internal/goproxytest"
 	"github.com/rogpeppe/go-internal/gotooltest"
@@ -293,12 +292,6 @@ func (tr *testRunner) run(runDir, filename string) error {
 			}
 		}()
 		testscript.RunT(r, p)
-
-		// When continueOnError is true, FailNow does not call panic(failedRun).
-		// We still want err to be set, as the script resulted in a failure.
-		if r.Failed() {
-			err = failedRun
-		}
 	}()
 
 	if err != nil {
@@ -348,7 +341,6 @@ func renderFilename(filename string) string {
 // runT implements testscript.T and is used in the call to testscript.Run
 type runT struct {
 	verbose bool
-	failed  int32
 }
 
 func (r *runT) Skip(is ...interface{}) {
@@ -370,12 +362,7 @@ func (r *runT) Log(is ...interface{}) {
 }
 
 func (r *runT) FailNow() {
-	atomic.StoreInt32(&r.failed, 1)
 	panic(failedRun)
-}
-
-func (r *runT) Failed() bool {
-	return atomic.LoadInt32(&r.failed) != 0
 }
 
 func (r *runT) Run(n string, f func(t testscript.T)) {

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -219,8 +219,7 @@ type T interface {
 	Verbose() bool
 }
 
-// TFailed holds optional extra methods implemented on T.
-// It's defined as a separate type for backward compatibility reasons.
+// Deprecated: this type is unused.
 type TFailed interface {
 	Failed() bool
 }

--- a/testscript/testscript_test.go
+++ b/testscript/testscript_test.go
@@ -508,7 +508,3 @@ func (t *fakeT) Run(name string, f func(T)) {
 func (t *fakeT) Verbose() bool {
 	return t.verbose
 }
-
-func (t *fakeT) Failed() bool {
-	return t.failed
-}


### PR DESCRIPTION
The call to `T.Failed` and its associated comment are a legacy of previous implementation. The comment isn't accurate and the call isn't necessary (`FailNow` is always called even when `ContinueOnError` is set). Deprecate the associated `TFailed` type rather than removing it.