### PR TITLE
testscript: add Config.Files

### DIFF
--- a/cmd/testscript/testdata/work.txt
+++ b/cmd/testscript/testdata/work.txt
@@ -13,7 +13,7 @@ stderr '^temporary work directory: \Q'$WORK'\E[/\\]\.tmp[/\\]'
 stderr '^temporary work directory for file.txt: \Q'$WORK'\E[/\\]\.tmp[/\\]'
 stderr '^temporary work directory for dir[/\\]file.txt: \Q'$WORK'\E[/\\]\.tmp[/\\]'
 expandone $WORK/.tmp/testscript*/file.txt/script.txtar
-expandone $WORK/.tmp/testscript*/file.txt1/script.txtar
+expandone $WORK/.tmp/testscript*/file.txt#1/script.txtar
 
 -- file.txt --
 >exec true

--- a/testscript/testdata/big_diff.txt
+++ b/testscript/testdata/big_diff.txt
@@ -7,6 +7,7 @@ env
 cmpenv stdout stdout.golden
 
 -- stdout.golden --
+** RUN script **
 > cmp a b
 diff a b
 --- a

--- a/testscript/testdata/long_diff.txt
+++ b/testscript/testdata/long_diff.txt
@@ -110,6 +110,7 @@ cmpenv stdout stdout.golden
 >a
 >a
 -- stdout.golden --
+** RUN script **
 > cmp a b
 diff a b
 --- a

--- a/testscript/testdata/testscript_explicit_files.txt
+++ b/testscript/testdata/testscript_explicit_files.txt
@@ -1,0 +1,26 @@
+# Check that we can pass an explicit set of files to be tested.
+! testscript -files foo.txtar x/bar.txtar y/bar.txtar 'y/bar#1.txtar'
+cmpenv stdout expect-stdout
+-- expect-stdout --
+** RUN foo **
+PASS
+** RUN bar **
+PASS
+** RUN bar#1 **
+> echoandexit 1 '' 'bar#1 failure'
+[stderr]
+bar#1 failure
+FAIL: $$WORK${/}y${/}bar.txtar:1: told to exit with code 1
+** RUN bar#1#1 **
+> echoandexit 1 '' 'bar#1#1 failure'
+[stderr]
+bar#1#1 failure
+FAIL: $$WORK${/}y${/}bar#1.txtar:1: told to exit with code 1
+-- foo.txtar --
+echoandexit 0 '' 'foo failure'
+-- x/bar.txtar --
+echoandexit 0 '' 'bar failure'
+-- y/bar.txtar --
+echoandexit 1 '' 'bar#1 failure'
+-- y/bar#1.txtar --
+echoandexit 1 '' 'bar#1#1 failure'

--- a/testscript/testdata/testscript_logging.txt
+++ b/testscript/testdata/testscript_logging.txt
@@ -33,6 +33,7 @@ printargs section5
 status 1
 
 -- expect-stdout.txt --
+** RUN testscript **
 # comment 1 (0.000s)
 # comment 2 (0.000s)
 # comment 3 (0.000s)
@@ -43,6 +44,7 @@ status 1
 [exit status 1]
 FAIL: $$WORK${/}scripts${/}testscript.txt:9: unexpected command failure
 -- expect-stdout-v.txt --
+** RUN testscript **
 # comment 1 (0.000s)
 > printargs section1
 [stdout]
@@ -59,6 +61,7 @@ FAIL: $$WORK${/}scripts${/}testscript.txt:9: unexpected command failure
 [exit status 1]
 FAIL: $$WORK${/}scripts${/}testscript.txt:9: unexpected command failure
 -- expect-stdout-c.txt --
+** RUN testscript **
 # comment 1 (0.000s)
 # comment 2 (0.000s)
 # comment 3 (0.000s)
@@ -80,6 +83,7 @@ FAIL: $$WORK${/}scripts${/}testscript.txt:9: unexpected command failure
 [exit status 1]
 FAIL: $$WORK${/}scripts${/}testscript.txt:16: unexpected command failure
 -- expect-stdout-vc.txt --
+** RUN testscript **
 # comment 1 (0.000s)
 > printargs section1
 [stdout]

--- a/testscript/testdata/testscript_stdout_stderr_error.txt
+++ b/testscript/testdata/testscript_stdout_stderr_error.txt
@@ -9,6 +9,7 @@ cmpenv stdout stdout.golden
 > printargs hello world
 > echoandexit 1 'this is stdout' 'this is stderr'
 -- stdout.golden --
+** RUN testscript **
 >  printargs hello world
 [stdout]
 ["printargs" "hello" "world"]


### PR DESCRIPTION
This makes it possible to pass an arbitrary set of testscript files to be run instead of just a directory, making it possible for the testscript command to pass its command line arguments directly.

In order to check that all the files are actually tested, we need to make the test harness implement independent subtest failure, and it's useful to see the name of the test too so that we can see the name disambiguation logic at work, which makes for changes to some of the other tests too.

Note that the name deduping logic is somewhat improved from similar logic in cmd/testscript, in that it is always guaranteed to produce unique names even in the presence of filenames that look like deduped names.