### PR TITLE
hash: do not salt with Go runtime version

### DIFF
--- a/cache/hash.go
+++ b/cache/hash.go
@@ -11,7 +11,6 @@ import (
 	"hash"
 	"io"
 	"os"
-	"runtime"
 	"strings"
 	"sync"
 )
@@ -28,22 +27,6 @@ type Hash struct {
 	name string        // for debugging
 	buf  *bytes.Buffer // for verify
 }
-
-// hashSalt is a salt string added to the beginning of every hash
-// created by NewHash. Using the Go version makes sure that different
-// versions of the go command (or even different Git commits during
-// work on the development branch) do not address the same cache
-// entries, so that a bug in one version does not affect the execution
-// of other versions. This salt will result in additional ActionID files
-// in the cache, but not additional copies of the large output files,
-// which are still addressed by unsalted SHA256.
-//
-// We strip any GOEXPERIMENTs the go tool was built with from this
-// version string on the assumption that they shouldn't affect go tool
-// execution. This allows bootstrapping to converge faster: dist builds
-// go_bootstrap without any experiments, so by stripping experiments
-// go_bootstrap and the final go binary will use the same salt.
-var hashSalt = []byte(stripExperiment(runtime.Version()))
 
 // stripExperiment strips any GOEXPERIMENT configuration from the Go
 // version string.
@@ -81,7 +64,6 @@ func NewHash(name string) *Hash {
 	if debugHash {
 		fmt.Fprintf(os.Stderr, "HASH[%s]\n", h.name)
 	}
-	h.Write(hashSalt)
 	if verify {
 		h.buf = new(bytes.Buffer)
 	}

--- a/cache/hash_test.go
+++ b/cache/hash_test.go
@@ -11,12 +11,6 @@ import (
 )
 
 func TestHash(t *testing.T) {
-	oldSalt := hashSalt
-	hashSalt = nil
-	defer func() {
-		hashSalt = oldSalt
-	}()
-
 	h := NewHash("alice")
 	h.Write([]byte("hello world"))
 	sum := fmt.Sprintf("%x", h.Sum())


### PR DESCRIPTION
Currently the cache code, taken directly from the Go internal code, salts every hash with the current Go runtime version. This is appropriate for Go itself but not for here where the cache package is intended for more general use.

People that need the hashes to depend on the Go runtime version can explicitly include it as part of the hash.