### PR TITLE
goproxytest: add Setup

### DIFF
--- a/cmd/testscript/main.go
+++ b/cmd/testscript/main.go
@@ -11,20 +11,12 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync/atomic"
 
 	"github.com/rogpeppe/go-internal/goproxytest"
 	"github.com/rogpeppe/go-internal/gotooltest"
 	"github.com/rogpeppe/go-internal/testscript"
-)
-
-const (
-	// goModProxyDir is the special subdirectory in a txtar script's supporting files
-	// within which we expect to find github.com/rogpeppe/go-internal/goproxytest
-	// directories.
-	goModProxyDir = ".gomodproxy"
 )
 
 type envVarsFlag struct {
@@ -120,6 +112,7 @@ func mainerr() (retErr error) {
 			return fmt.Errorf("failed to setup go tool: %v", err)
 		}
 	}
+	goproxytest.Setup(&p)
 	origSetup := p.Setup
 	p.Setup = func(env *testscript.Env) error {
 		if err := origSetup(env); err != nil {
@@ -127,21 +120,6 @@ func mainerr() (retErr error) {
 		}
 		if *fWork {
 			env.T().Log("temporary work directory: ", env.WorkDir)
-		}
-		proxyDir := filepath.Join(env.WorkDir, goModProxyDir)
-		if info, err := os.Stat(proxyDir); err == nil && info.IsDir() {
-			srv, err := goproxytest.NewServer(proxyDir, "")
-			if err != nil {
-				return fmt.Errorf("cannot start Go proxy: %v", err)
-			}
-			env.Defer(srv.Close)
-
-			// Add GOPROXY after calling the original setup
-			// so that it overrides any GOPROXY set there.
-			env.Vars = append(env.Vars,
-				"GOPROXY="+srv.URL,
-				"GONOSUMDB=*",
-			)
 		}
 		for _, v := range envVars.vals {
 			varName, _, ok := strings.Cut(v, "=")

--- a/goproxytest/proxy_test.go
+++ b/goproxytest/proxy_test.go
@@ -30,3 +30,50 @@ func TestScripts(t *testing.T) {
 	}
 	testscript.Run(t, p)
 }
+
+func TestSetup(t *testing.T) {
+	t.Run("with_proxy", func(t *testing.T) {
+		p := testscript.Params{
+			Files: []string{
+				filepath.Join("testdata", "setup", "with_proxy.txt"),
+			},
+		}
+		if err := gotooltest.Setup(&p); err != nil {
+			t.Fatal(err)
+		}
+		goproxytest.Setup(&p)
+		testscript.Run(t, p)
+	})
+	t.Run("no_proxy", func(t *testing.T) {
+		p := testscript.Params{
+			Files: []string{
+				filepath.Join("testdata", "setup", "no_proxy.txt"),
+			},
+			Setup: func(e *testscript.Env) error {
+				e.Vars = append(e.Vars, "GOPROXY=original")
+				return nil
+			},
+		}
+		if err := gotooltest.Setup(&p); err != nil {
+			t.Fatal(err)
+		}
+		goproxytest.Setup(&p)
+		testscript.Run(t, p)
+	})
+	t.Run("chained", func(t *testing.T) {
+		p := testscript.Params{
+			Files: []string{
+				filepath.Join("testdata", "setup", "chained.txt"),
+			},
+			Setup: func(e *testscript.Env) error {
+				e.Vars = append(e.Vars, "CUSTOM=hello")
+				return nil
+			},
+		}
+		if err := gotooltest.Setup(&p); err != nil {
+			t.Fatal(err)
+		}
+		goproxytest.Setup(&p)
+		testscript.Run(t, p)
+	})
+}

--- a/goproxytest/setup.go
+++ b/goproxytest/setup.go
@@ -1,0 +1,51 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package goproxytest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rogpeppe/go-internal/testscript"
+)
+
+// GoModProxyDir is the name of the special subdirectory in a txtar script's
+// supporting files within which module archives for goproxytest are expected
+// to be found.
+const GoModProxyDir = ".gomodproxy"
+
+// Setup sets up the given test parameters so that test scripts that
+// contain a [GoModProxyDir] directory will have GOPROXY set to
+// serve modules from that directory using a localhost proxy server.
+//
+// It wraps p.Setup to start a proxy server when the directory is present,
+// set GOPROXY and GONOSUMDB appropriately, and shuts down
+// the server when the test completes.
+func Setup(p *testscript.Params) {
+	origSetup := p.Setup
+	p.Setup = func(env *testscript.Env) error {
+		if origSetup != nil {
+			if err := origSetup(env); err != nil {
+				return err
+			}
+		}
+		proxyDir := filepath.Join(env.WorkDir, GoModProxyDir)
+		if info, err := os.Stat(proxyDir); err == nil && info.IsDir() {
+			srv, err := NewServer(proxyDir, "")
+			if err != nil {
+				return fmt.Errorf("cannot start Go proxy: %v", err)
+			}
+			env.Defer(srv.Close)
+			// Add GOPROXY after calling the original setup
+			// so that it overrides any GOPROXY set there.
+			env.Vars = append(env.Vars,
+				"GOPROXY="+srv.URL,
+				"GONOSUMDB=*",
+			)
+		}
+		return nil
+	}
+}

--- a/goproxytest/testdata/setup/chained.txt
+++ b/goproxytest/testdata/setup/chained.txt
@@ -1,0 +1,36 @@
+# Verify that goproxytest.Setup chains with an existing Setup function.
+# The custom setup sets CUSTOM=hello, and then Setup should also set GOPROXY.
+go env GOPROXY
+stdout ^http://.*/mod$
+
+go run main.go
+stdout ^hello$
+
+-- go.mod --
+module mod
+
+-- main.go --
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println(os.Getenv("CUSTOM"))
+}
+
+-- .gomodproxy/fruit.com_v1.0.0/.mod --
+module fruit.com
+
+-- .gomodproxy/fruit.com_v1.0.0/.info --
+{"Version":"v1.0.0","Time":"2018-10-22T18:45:39Z"}
+
+-- .gomodproxy/fruit.com_v1.0.0/go.mod --
+module fruit.com
+
+-- .gomodproxy/fruit.com_v1.0.0/fruit/fruit.go --
+package fruit
+
+const Name = "Apple"

--- a/goproxytest/testdata/setup/no_proxy.txt
+++ b/goproxytest/testdata/setup/no_proxy.txt
@@ -1,0 +1,7 @@
+# Verify that goproxytest.Setup does not set GOPROXY
+# when there's no .gomodproxy directory.
+go env GOPROXY
+stdout ^original$
+
+-- go.mod --
+module mod

--- a/goproxytest/testdata/setup/with_proxy.txt
+++ b/goproxytest/testdata/setup/with_proxy.txt
@@ -1,0 +1,26 @@
+# Verify that goproxytest.Setup sets GOPROXY when .gomodproxy is present
+# and that the proxy actually serves modules.
+go env GOPROXY
+stdout ^http://.*/mod$
+
+go list -m -versions fruit.com
+stdout 'v1.0.0'
+
+go get -d fruit.com@v1.0.0
+
+-- go.mod --
+module mod
+
+-- .gomodproxy/fruit.com_v1.0.0/.mod --
+module fruit.com
+
+-- .gomodproxy/fruit.com_v1.0.0/.info --
+{"Version":"v1.0.0","Time":"2018-10-22T18:45:39Z"}
+
+-- .gomodproxy/fruit.com_v1.0.0/go.mod --
+module fruit.com
+
+-- .gomodproxy/fruit.com_v1.0.0/fruit/fruit.go --
+package fruit
+
+const Name = "Apple"


### PR DESCRIPTION
The testscript command supports putting Go proxy files inside the same txtar file as everything else, but that functionality isn't easily available to regular testscript users. Address that by adding a `Setup` function that works in the same fashion as `gotooltest.Setup`, and make the testscript command use it.