### PR TITLE
goproxytest: add overlay capability

### DIFF
--- a/goproxytest/proxy.go
+++ b/goproxytest/proxy.go
@@ -95,7 +95,7 @@ func newServer(dir, addr string, logf func(string, ...any)) (*Server, error) {
 	srv.URL = "http://" + addr + "/mod"
 	go func() {
 		if err := srv.server.Serve(l); err != nil && err != http.ErrServerClosed {
-			srv.logf("go proxy: http.Serve: %v", err)
+			srv.logf("go proxy_test http.Serve: %v", err)
 		}
 	}()
 	return &srv, nil
@@ -258,7 +258,6 @@ func (srv *Server) handler(w http.ResponseWriter, r *http.Request) {
 		// to resolve github.com, github.com/hello and github.com/hello/world.
 		// cmd/go expects a 404/410 response if there is nothing there. Hence we
 		// cannot return with a 500.
-		srv.logf("go proxy: no archive %s %s\n", path, vers)
 		http.NotFound(w, r)
 		return
 	}
@@ -300,7 +299,7 @@ func (srv *Server) handler(w http.ResponseWriter, r *http.Request) {
 		}).(cached)
 
 		if c.err != nil {
-			srv.logf("go proxy: %v\n", c.err)
+			srv.logf("go proxy_test %v\n", c.err)
 			http.Error(w, c.err.Error(), 500)
 			return
 		}
@@ -331,12 +330,12 @@ func (srv *Server) findHash(m module.Version) string {
 func (srv *Server) readArchive(path, vers string) *txtar.Archive {
 	enc, err := module.EscapePath(path)
 	if err != nil {
-		srv.logf("go proxy: %v\n", err)
+		srv.logf("go proxy_test %v\n", err)
 		return nil
 	}
 	encVers, err := module.EscapeVersion(vers)
 	if err != nil {
-		srv.logf("go proxy: %v\n", err)
+		srv.logf("go proxy_test %v\n", err)
 		return nil
 	}
 
@@ -378,7 +377,7 @@ func (srv *Server) readArchive(path, vers string) *txtar.Archive {
 		}
 		if err != nil {
 			if !os.IsNotExist(err) {
-				srv.logf("go proxy: %v\n", err)
+				srv.logf("go proxy_test %v\n", err)
 			}
 			a = nil
 		}

--- a/goproxytest/proxy_test.go
+++ b/goproxytest/proxy_test.go
@@ -38,7 +38,7 @@ func TestSetup(t *testing.T) {
 	t.Run("with_proxy", func(t *testing.T) {
 		p := testscript.Params{
 			Files: []string{
-				filepath.Join("testdata", "setup", "with_proxy.txt"),
+				"testdata/setup/with_proxy.txt",
 			},
 		}
 		if err := gotooltest.Setup(&p); err != nil {
@@ -50,7 +50,7 @@ func TestSetup(t *testing.T) {
 	t.Run("no_proxy", func(t *testing.T) {
 		p := testscript.Params{
 			Files: []string{
-				filepath.Join("testdata", "setup", "no_proxy.txt"),
+				"testdata/setup/no_proxy.txt",
 			},
 			Setup: func(e *testscript.Env) error {
 				e.Vars = append(e.Vars, "GOPROXY=original")
@@ -66,11 +66,23 @@ func TestSetup(t *testing.T) {
 	t.Run("chained", func(t *testing.T) {
 		p := testscript.Params{
 			Files: []string{
-				filepath.Join("testdata", "setup", "chained.txt"),
+				"testdata/setup/chained.txt",
 			},
 			Setup: func(e *testscript.Env) error {
 				e.Vars = append(e.Vars, "CUSTOM=hello")
 				return nil
+			},
+		}
+		if err := gotooltest.Setup(&p); err != nil {
+			t.Fatal(err)
+		}
+		goproxytest.Setup(&p)
+		testscript.Run(t, p)
+	})
+	t.Run("overlay", func(t *testing.T) {
+		p := testscript.Params{
+			Files: []string{
+				"testdata/setup/overlay.txt",
 			},
 		}
 		if err := gotooltest.Setup(&p); err != nil {

--- a/goproxytest/setup.go
+++ b/goproxytest/setup.go
@@ -6,9 +6,13 @@ package goproxytest
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
+	"unicode"
 
+	"github.com/rogpeppe/go-internal/internal/goenv"
 	"github.com/rogpeppe/go-internal/testscript"
 )
 
@@ -24,6 +28,13 @@ const GoModProxyDir = ".gomodproxy"
 // It wraps p.Setup to start a proxy server when the directory is present,
 // set GOPROXY and GONOSUMDB appropriately, and shuts down
 // the server when the test completes.
+//
+// If a file exists in the top level of the [GoModProxyDir] directory
+// named "_enable_overlay", then instead of replacing the Go proxy entirely, the
+// existing Go proxy is used to serve modules that are not present in
+// the test script. In this case it uses the existing GOMODPROXY
+// download cache to avoid network downloads if it can, but takes care
+// not to pollute it with the localhost proxy server content.
 func Setup(p *testscript.Params) {
 	origSetup := p.Setup
 	p.Setup = func(env *testscript.Env) error {
@@ -33,19 +44,84 @@ func Setup(p *testscript.Params) {
 			}
 		}
 		proxyDir := filepath.Join(env.WorkDir, GoModProxyDir)
-		if info, err := os.Stat(proxyDir); err == nil && info.IsDir() {
-			srv, err := NewServer(proxyDir, "")
-			if err != nil {
-				return fmt.Errorf("cannot start Go proxy: %v", err)
+		info, err := os.Stat(proxyDir)
+		if err != nil || !info.IsDir() {
+			return nil
+		}
+		srv, err := NewServer(proxyDir, "")
+		if err != nil {
+			return fmt.Errorf("cannot start Go proxy: %v", err)
+		}
+		env.Defer(srv.Close)
+
+		env.Vars = append(env.Vars, "GONOSUMDB=*")
+		if info, err := os.Stat(filepath.Join(proxyDir, "_enable_overlay")); err == nil && info.Mode().IsRegular() {
+			// Overlay is enabled: overlay rather than replacing the proxy.
+			// NOTE: if you change the list of names here, make sure
+			// to keep ../internal/goenv/goenv.go:/^var goEnv
+			// up to date.
+			var goEnv struct {
+				GOMODCACHE string
+				GOPROXY    string
+				GONOPROXY  string
 			}
-			env.Defer(srv.Close)
-			// Add GOPROXY after calling the original setup
-			// so that it overrides any GOPROXY set there.
+			if err := goenv.Unmarshal(&goEnv); err != nil {
+				return err
+			}
+			if goEnv.GOMODCACHE == "" || goEnv.GOPROXY == "" {
+				// Shouldn't happen.
+				return fmt.Errorf("missing GOMODCACHE or GOPROXY from go env output")
+			}
+			// Look for local test modules first, falling back to the
+			// existing module download cache. See example under the
+			// GOPROXY entry in https://go.dev/ref/mod#environment-variables
 			env.Vars = append(env.Vars,
-				"GOPROXY="+srv.URL,
-				"GONOSUMDB=*",
+				fmt.Sprintf("GOPROXY=%s,%s,%s",
+					srv.URL,
+					uriFromPath(filepath.Join(goEnv.GOMODCACHE, "/cache/download")),
+					goEnv.GOPROXY,
+				),
+				// Pass through the following variables on the grounds that
+				// they should be used when fetching external modules.
+				// Hopefully they will be immaterial because tests shouldn't
+				// be relying on modules that match them, but it seems safer
+				// to do this.
+				"GONOPROXY="+goEnv.GONOPROXY,
 			)
+		} else {
+			env.Vars = append(env.Vars, "GOPROXY="+srv.URL)
 		}
 		return nil
 	}
+}
+
+// uriFromPath returns a file:// URI for the supplied file path.
+// This code was adapted from cuelang.org/go/internal/golangorgx/gopls/protocol.URIFromPath
+func uriFromPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	if !isWindowsDrivePath(path) {
+		if abs, err := filepath.Abs(path); err == nil {
+			path = abs
+		}
+	}
+	// Check the file path again, in case it became absolute.
+	if isWindowsDrivePath(path) {
+		path = "/" + strings.ToUpper(string(path[0])) + path[1:]
+	}
+	return (&url.URL{
+		Scheme: "file",
+		Path:   filepath.ToSlash(path),
+	}).String()
+}
+
+// isWindowsDrivePath returns true if the file path is of the form used by
+// Windows. We check if the path begins with a drive letter, followed by a ":".
+// For example: C:/x/y/z.
+func isWindowsDrivePath(path string) bool {
+	if len(path) < 3 {
+		return false
+	}
+	return unicode.IsLetter(rune(path[0])) && path[1] == ':'
 }

--- a/goproxytest/testdata/setup/overlay.txt
+++ b/goproxytest/testdata/setup/overlay.txt
@@ -1,0 +1,34 @@
+# Verify that goproxytest.Setup sets GOPROXY when .gomodproxy is present
+# and that the proxy actually serves modules.
+go env GOPROXY
+stdout ^http://.*/mod,file://.*$
+
+go list -m -versions fruit.com
+stdout 'v1.0.0'
+
+go get -d fruit.com@v1.0.0
+
+# The goproxytest package information should definitely be available
+# and cached.
+go get -d github.com/rogpeppe/go-internal/goproxytest
+
+-- go.mod --
+module mod
+
+-- .gomodproxy/_enable_overlay --
+We want to be able to use regular Go modules as well as test-related
+ones. The contents of this file are ignored; only
+its presence is necessary.
+-- .gomodproxy/fruit.com_v1.0.0/.mod --
+module fruit.com
+
+-- .gomodproxy/fruit.com_v1.0.0/.info --
+{"Version":"v1.0.0","Time":"2018-10-22T18:45:39Z"}
+
+-- .gomodproxy/fruit.com_v1.0.0/go.mod --
+module fruit.com
+
+-- .gomodproxy/fruit.com_v1.0.0/fruit/fruit.go --
+package fruit
+
+const Name = "Apple"

--- a/gotooltest/setup.go
+++ b/gotooltest/setup.go
@@ -8,7 +8,6 @@ package gotooltest
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -18,6 +17,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/rogpeppe/go-internal/internal/goenv"
 	"github.com/rogpeppe/go-internal/testscript"
 )
 
@@ -74,18 +74,9 @@ func initGoEnv() (err error) {
 	tagStr = strings.Trim(tagStr, "[]")
 	goEnv.releaseTags = strings.Split(tagStr, " ")
 
-	eout, stderr, err := run("go", "env", "-json",
-		"GOROOT",
-		"GOCACHE",
-		"GOPROXY",
-	)
-	if err != nil {
-		return fmt.Errorf("failed to determine environment from go command: %v\n%v", err, stderr)
+	if err := goenv.Unmarshal(&goEnv); err != nil {
+		return err
 	}
-	if err := json.Unmarshal(eout.Bytes(), &goEnv); err != nil {
-		return fmt.Errorf("failed to unmarshal GOROOT and GOCACHE tags from go command out: %v\n%v", err, eout)
-	}
-
 	version := goEnv.releaseTags[len(goEnv.releaseTags)-1]
 	if !goVersionRegex.MatchString(version) {
 		return fmt.Errorf("invalid go version %q", version)

--- a/internal/goenv/goenv.go
+++ b/internal/goenv/goenv.go
@@ -1,0 +1,45 @@
+// goenv is used by various testscript-related package to avoid
+// invoking `go env` multiple times independently
+// when a single execution is sufficient.
+package goenv
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"sync"
+)
+
+// Unmarshal JSON-unmarshals the result of `go env -json` into the value pointed
+// to by dst.
+func Unmarshal(dst any) error {
+	data, err := goEnv()
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, dst); err != nil {
+		return fmt.Errorf("failed to unmarshal environment from go command out: %v\n%s", err, data)
+	}
+	return nil
+}
+
+var goEnv = sync.OnceValues(func() ([]byte, error) {
+	var stdout, stderr bytes.Buffer
+	// Note: we explicitly mention all the variables that
+	// any of the callers of goenv might need to avoid
+	// fetching any of the variables that are costly to calculate.
+	cmd := exec.Command("go", "env", "-json",
+		"GOCACHE",
+		"GOMODCACHE",
+		"GONOPROXY",
+		"GOPROXY",
+		"GOROOT",
+	)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to determine environment from go command: %v\n%v", err, &stderr)
+	}
+	return stdout.Bytes(), nil
+})


### PR DESCRIPTION
It's useful to have a hybrid mode where some modules are served from the txtar contents but others come from the regular Go sources. We make goproxytest
capable of doing that: adding a file named `OVERLAY` to the top level `.gomodproxy` directory triggers that behavior.