### PR TITLE
testscript: add dynamic command capability

### DIFF
--- a/testscript/testdata/setcmd.txt
+++ b/testscript/testdata/setcmd.txt
@@ -1,0 +1,19 @@
+# A command registered with SetCmd becomes available for the rest of the test.
+register greet 'hello world'
+greet
+stdout '^hello world$'
+
+# A second registration works too, and re-registering replaces the command.
+register other 'goodbye'
+other
+stdout '^goodbye$'
+
+register greet 'hi again'
+greet
+stdout '^hi again$'
+
+# Registry a random name and check that it's not exec-able
+# (we're registering commands not executables)
+env name=d8e3ec30-d063-4f54-a9e6-b40eb830252a
+register $name x
+! exec $name

--- a/testscript/testscript.go
+++ b/testscript/testscript.go
@@ -373,20 +373,27 @@ func RunT(t T, p Params) {
 
 // A TestScript holds execution state for a single test script.
 type TestScript struct {
-	params        Params
-	t             T
-	testTempDir   string
-	workdir       string            // temporary work dir ($WORK)
-	log           bytes.Buffer      // test execution log (printed at end of test)
-	mark          int               // offset of next log truncation
-	cd            string            // current directory during test execution; initially $WORK/gopath/src
-	name          string            // short name of test ("foo")
-	file          string            // full file name ("testdata/script/foo.txt")
-	lineno        int               // line number currently executing
-	line          string            // line currently executing
-	env           []string          // environment list (for os/exec)
-	envMap        map[string]string // environment mapping (matches env; on Windows keys are lowercase)
-	values        map[any]any       // values for custom commands
+	params      Params
+	t           T
+	testTempDir string
+	workdir     string            // temporary work dir ($WORK)
+	log         bytes.Buffer      // test execution log (printed at end of test)
+	mark        int               // offset of next log truncation
+	cd          string            // current directory during test execution; initially $WORK/gopath/src
+	name        string            // short name of test ("foo")
+	file        string            // full file name ("testdata/script/foo.txt")
+	lineno      int               // line number currently executing
+	line        string            // line currently executing
+	env         []string          // environment list (for os/exec)
+	envMap      map[string]string // environment mapping (matches env; on Windows keys are lowercase)
+	values      map[any]any       // values for custom commands
+
+	// localCmds holds commands registered for the current test only,
+	// via SetCmd. It takes precedence over Params.Cmds but not over the
+	// builtin commands. It is only ever accessed from the test's own
+	// goroutine, so needs no locking.
+	localCmds map[string]func(*TestScript, bool, []string)
+
 	stdin         string            // standard input to next 'go' command; set by 'stdin' command.
 	stdout        string            // standard output from last 'go' command; for 'stdout' command
 	stderr        string            // standard error from last 'go' command; for 'stderr' command
@@ -441,6 +448,24 @@ func writeFile(name string, data []byte, perm fs.FileMode, excl bool) error {
 
 // Name returns the short name or basename of the test script.
 func (ts *TestScript) Name() string { return ts.name }
+
+// SetCmd registers cmd as the implementation of the named command for the
+// remainder of the current test only. It is intended for commands (such as
+// those provided by plugins) that become available partway through a script.
+// A nil cmd removes any previously registered command of that name.
+//
+// A command registered with SetCmd takes precedence over a command of the
+// same name in [Params.Cmds] but cannot override a builtin command.
+func (ts *TestScript) SetCmd(name string, cmd func(ts *TestScript, neg bool, args []string)) {
+	if cmd == nil {
+		delete(ts.localCmds, name)
+		return
+	}
+	if ts.localCmds == nil {
+		ts.localCmds = make(map[string]func(*TestScript, bool, []string))
+	}
+	ts.localCmds[name] = cmd
+}
 
 // setup sets up the test execution temporary directory and environment.
 // It returns the comment section of the txtar archive.
@@ -732,8 +757,12 @@ func (ts *TestScript) runLine(line string) (runOK bool) {
 		}
 	}
 
-	// Run command.
+	// Run command. Builtins take precedence, then commands registered
+	// for this test via SetCmd, then the static Params.Cmds.
 	cmd := scriptCmds[args[0]]
+	if cmd == nil {
+		cmd = ts.localCmds[args[0]]
+	}
 	if cmd == nil {
 		cmd = ts.params.Cmds[args[0]]
 	}
@@ -778,12 +807,20 @@ func (ts *TestScript) cmdSuggestions(name string) []string {
 		if _, ok := scriptCmds[name[1:]]; ok {
 			return []string{"! " + name[1:]}
 		}
+		if _, ok := ts.localCmds[name[1:]]; ok {
+			return []string{"! " + name[1:]}
+		}
 		if _, ok := ts.params.Cmds[name[1:]]; ok {
 			return []string{"! " + name[1:]}
 		}
 	}
 	var candidates []string
 	for c := range scriptCmds {
+		if misspell.AlmostEqual(name, c) {
+			candidates = append(candidates, c)
+		}
+	}
+	for c := range ts.localCmds {
 		if misspell.AlmostEqual(name, c) {
 			candidates = append(candidates, c)
 		}

--- a/testscript/testscript_test.go
+++ b/testscript/testscript_test.go
@@ -175,8 +175,19 @@ func TestScripts(t *testing.T) {
 		Cmds: map[string]func(ts *TestScript, neg bool, args []string){
 			"setSpecialVal":    setSpecialVal,
 			"ensureSpecialVal": ensureSpecialVal,
-			"interrupt":        interrupt,
-			"waitfile":         waitFile,
+			"register": func(ts *TestScript, neg bool, args []string) {
+				// register <name> <text> dynamically defines a command
+				// that writes <text> to stdout, for the rest of the test.
+				if len(args) != 2 {
+					ts.Fatalf("usage: register <name> <text>")
+				}
+				text := args[1]
+				ts.SetCmd(args[0], func(ts *TestScript, neg bool, args []string) {
+					fmt.Fprintln(ts.Stdout(), text)
+				})
+			},
+			"interrupt": interrupt,
+			"waitfile":  waitFile,
 			"testdefer": func(ts *TestScript, neg bool, args []string) {
 				testDeferCount++
 				n := testDeferCount


### PR DESCRIPTION
This allows a command to be able to add more commands, which is useful for the up-coming plugin functionality.