### PR TITLE
testscript/plugin: new package

### DIFF
--- a/cmd/testscript/main.go
+++ b/cmd/testscript/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rogpeppe/go-internal/goproxytest"
 	"github.com/rogpeppe/go-internal/gotooltest"
 	"github.com/rogpeppe/go-internal/testscript"
+	"github.com/rogpeppe/go-internal/testscript/plugin"
 )
 
 type envVarsFlag struct {
@@ -98,7 +99,6 @@ func mainerr() (retErr error) {
 		files[i] = stdinTempFile
 		defer os.Remove(stdinTempFile)
 	}
-
 	p := testscript.Params{
 		Setup:           func(*testscript.Env) error { return nil },
 		Files:           files,
@@ -106,12 +106,19 @@ func mainerr() (retErr error) {
 		ContinueOnError: *fContinue,
 		TestWork:        *fWork,
 	}
+	cleanup, err := plugin.Setup(&p)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
 
 	if _, err := exec.LookPath("go"); err == nil {
 		if err := gotooltest.Setup(&p); err != nil {
 			return fmt.Errorf("failed to setup go tool: %v", err)
 		}
 	}
+	// When a script provides a .gomodproxy directory, serve those modules
+	// from a local proxy, overriding any GOPROXY set above.
 	goproxytest.Setup(&p)
 	origSetup := p.Setup
 	p.Setup = func(env *testscript.Env) error {

--- a/testscript/plugin/client.go
+++ b/testscript/plugin/client.go
@@ -1,0 +1,162 @@
+package plugin
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// NewClient returns an implementation of [Interface] that issues JSON-RPC
+// requests to, and reads responses from, c. It performs an initial handshake
+// to fetch the plugin's [PluginInfo]. The connection c is closed when the
+// returned value's Close method is called.
+//
+// The returned value is safe for concurrent use; in particular the test
+// instances it creates may be used concurrently.
+func NewClient(c io.ReadWriteCloser) (Interface, error) {
+	cl := &client{
+		c:       c,
+		enc:     json.NewEncoder(c),
+		pending: make(map[uint64]chan rpcResponse),
+	}
+	go cl.readLoop()
+	var res infoResult
+	if err := cl.call(methodInfo, infoArgs{Version: protocolVersion}, &res); err != nil {
+		c.Close()
+		return nil, fmt.Errorf("plugin handshake failed: %v", err)
+	}
+	if res.Version > protocolVersion {
+		c.Close()
+		return nil, fmt.Errorf("plugin selected protocol version %d, greater than supported version %d", res.Version, protocolVersion)
+	}
+	cl.info = res.Info
+	return cl, nil
+}
+
+type client struct {
+	c    io.ReadWriteCloser
+	info PluginInfo
+
+	// mu guards the fields below it.
+	mu      sync.Mutex
+	enc     *json.Encoder
+	seq     uint64
+	pending map[uint64]chan rpcResponse
+	err     error // set once the read loop terminates
+}
+
+// readLoop reads responses from the connection and delivers each to the
+// goroutine waiting on its request id. When the connection fails it records
+// the error and wakes all waiting callers.
+func (cl *client) readLoop() {
+	dec := json.NewDecoder(cl.c)
+	for {
+		var resp rpcResponse
+		if err := dec.Decode(&resp); err != nil {
+			cl.mu.Lock()
+			cl.err = err
+			pending := cl.pending
+			cl.pending = nil
+			cl.mu.Unlock()
+			for _, ch := range pending {
+				close(ch)
+			}
+			return
+		}
+		cl.mu.Lock()
+		ch := cl.pending[resp.ID]
+		delete(cl.pending, resp.ID)
+		cl.mu.Unlock()
+		if ch != nil {
+			ch <- resp
+		}
+	}
+}
+
+// call sends a request and waits for its response, unmarshaling the result
+// into result (if non-nil). A non-empty response error is returned as an error.
+// TODO we could pass a context in here to enable timing out.
+func (cl *client) call(method string, arg, result any) error {
+	var params json.RawMessage
+	if arg != nil {
+		data, err := json.Marshal(arg)
+		if err != nil {
+			return err
+		}
+		params = data
+	}
+	ch := make(chan rpcResponse, 1)
+	cl.mu.Lock()
+	if cl.err != nil {
+		err := cl.err
+		cl.mu.Unlock()
+		return err
+	}
+	cl.seq++
+	id := cl.seq
+	cl.pending[id] = ch
+	err := cl.enc.Encode(rpcRequest{ID: id, Method: method, Params: params})
+	if err != nil {
+		delete(cl.pending, id)
+		cl.mu.Unlock()
+		return err
+	}
+	cl.mu.Unlock()
+
+	resp, ok := <-ch
+	if !ok {
+		// The read loop closed the channel: the connection failed.
+		cl.mu.Lock()
+		err := cl.err
+		cl.mu.Unlock()
+		if err == nil || err == io.EOF {
+			err = errors.New("plugin connection closed")
+		}
+		return err
+	}
+	if resp.Error != "" {
+		return errors.New(resp.Error)
+	}
+	if result != nil && len(resp.Result) > 0 {
+		return json.Unmarshal(resp.Result, result)
+	}
+	return nil
+}
+
+func (cl *client) Info() PluginInfo { return cl.info }
+
+func (cl *client) NewTestInstance(p TestParams) (TestInstance, error) {
+	var res newInstanceResult
+	if err := cl.call(methodNewInstance, p, &res); err != nil {
+		return nil, err
+	}
+	return &clientInstance{cl: cl, instID: res.InstID, env: res.Env}, nil
+}
+
+// Close closes the underlying connection, which signals the plugin server to
+// shut down.
+func (cl *client) Close() {
+	cl.c.Close()
+}
+
+type clientInstance struct {
+	cl     *client
+	instID int
+	env    map[string]string
+}
+
+func (i *clientInstance) Env() map[string]string { return i.env }
+
+func (i *clientInstance) RunCmd(p CmdParams) (CmdResult, error) {
+	var res CmdResult
+	if err := i.cl.call(methodRunCmd, runCmdArgs{InstID: i.instID, Params: p}, &res); err != nil {
+		return CmdResult{}, err
+	}
+	return res, nil
+}
+
+func (i *clientInstance) Close() {
+	i.cl.call(methodCloseInstance, closeInstanceArgs{InstID: i.instID}, nil)
+}

--- a/testscript/plugin/contract.go
+++ b/testscript/plugin/contract.go
@@ -1,0 +1,147 @@
+// Package plugin supports extending a testscript run with external plugin
+// binaries, and provides the contract and JSON-RPC bridge that those binaries
+// implement.
+//
+// A plugin is an executable named "testscript-plugin-<name>" found on $PATH.
+// It provides additional commands and services to a testscript run, and may
+// set environment variables. The testscript host discovers, starts and queries
+// a plugin lazily the first time a script runs the "plugin <name>" command;
+// enable this by calling [Setup].
+//
+// A plugin communicates with the host over JSON-RPC carried on its standard
+// input (requests) and standard output (responses). It may write freely to its
+// standard error for logging; the host captures this and reports it through the
+// log of the test that is interacting with the plugin, rather than letting it
+// interleave on the host's own standard error. A plugin binary's main is
+// essentially:
+//
+//	func main() {
+//		if err := plugin.Serve(myPlugin); err != nil {
+//			log.Fatal(err)
+//		}
+//	}
+//
+// where myPlugin implements [Interface].
+//
+// IMPORTANT: a plugin must not write anything other than JSON-RPC frames to
+// its standard output, or the protocol will be corrupted. Use standard error
+// (or the log package, whose default output is standard error) for logging.
+package plugin
+
+// Interface is implemented by a plugin. A single plugin process is shared by
+// all tests using it, so all methods must be safe for concurrent use.
+type Interface interface {
+	// Info returns static information about the plugin: the environment
+	// variables it requires and provides, and the commands it makes
+	// available to test scripts.
+	Info() PluginInfo
+
+	// NewTestInstance creates a new instance of the plugin for a single
+	// running test. Multiple instances may exist concurrently.
+	NewTestInstance(TestParams) (TestInstance, error)
+
+	// Close shuts the plugin down, releasing any global resources.
+	Close()
+}
+
+// PluginInfo holds static information about a plugin.
+type PluginInfo struct {
+	// RequiredEnv holds the set of environment variable names that the
+	// plugin needs to be passed when creating a test instance. Only these
+	// variables are sent to the plugin.
+	RequiredEnv map[string]bool
+
+	// ResultEnv holds the set of environment variable names that the
+	// plugin is allowed to set in the test environment. The host rejects
+	// any attempt to set a variable not in this set.
+	ResultEnv map[string]bool
+
+	// Cmds holds the set of commands provided by the plugin, keyed by
+	// command name. These commands become available to a test script after
+	// it runs the "plugin" command for this plugin.
+	Cmds map[string]CmdInfo
+}
+
+// TestParams holds the parameters for creating a new test instance.
+type TestParams struct {
+	// TestName is the name of the test that the instance is for.
+	TestName string
+
+	// PluginParamsDir is the absolute path of the directory holding
+	// plugin-specific parameters for the test, or empty if none was given.
+	PluginParamsDir string
+
+	// Env holds the values of the variables named in
+	// [PluginInfo.RequiredEnv], as resolved in the test environment.
+	Env map[string]string
+}
+
+// CmdInfo holds static information about a command provided by a plugin.
+type CmdInfo struct {
+	// RequiredEnv holds the set of environment variable names that the
+	// command needs passed to it. Only these variables are sent to the
+	// plugin when the command is run.
+	RequiredEnv map[string]bool
+
+	// WritesOutput indicates whether the command sets
+	// standard error and standard output.
+	WritesOutput bool
+}
+
+// TestInstance represents a running instance of a plugin for a single test.
+// Its methods may be called concurrently with those of other instances.
+type TestInstance interface {
+	// Env returns the environment variables that the instance wants to set
+	// in the test environment. Every key must be present in
+	// [PluginInfo.ResultEnv].
+	Env() map[string]string
+
+	// RunCmd runs one of the commands provided by the plugin. The returned
+	// error indicates a failure of the plugin itself (for example, the
+	// command could not be started); a failure of the command being run is
+	// reported via [CmdResult.Err].
+	RunCmd(CmdParams) (CmdResult, error)
+
+	// Close shuts the instance down, releasing any resources held for the
+	// test.
+	Close()
+}
+
+// CmdParams holds the parameters for running a plugin command.
+type CmdParams struct {
+	// Name is the name of the command being run.
+	Name string
+
+	// Args holds the command's arguments (not including the command name).
+	Args []string
+
+	// Dir is the absolute path of the working directory the command should
+	// run in.
+	Dir string
+
+	// Env holds the values of the variables named in the command's
+	// [CmdInfo.RequiredEnv], as resolved in the test environment.
+	Env map[string]string
+
+	// Stdin holds the standard input for the command.
+	Stdin []byte
+}
+
+// CmdResult holds the result of running a plugin command.
+type CmdResult struct {
+	// Stdout and Stderr hold the command's standard output and standard
+	// error respectively.
+	Stdout []byte
+	Stderr []byte
+
+	// Env holds environment variables that the command wants to set in
+	// the test environment. Every key must be present in
+	// [PluginInfo.ResultEnv].
+	Env map[string]string
+
+	// Err, if non-empty, holds the error message from a failure of the
+	// command itself (for example a non-zero exit status). It is distinct
+	// from the error returned by [TestInstance.RunCmd], which indicates a
+	// failure of the plugin.
+	Err string
+}

--- a/testscript/plugin/plugin.go
+++ b/testscript/plugin/plugin.go
@@ -1,0 +1,276 @@
+package plugin
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/rogpeppe/go-internal/testscript"
+)
+
+// Setup registers the "plugin" command into p so that test scripts can use
+// plugins. Plugins are discovered, started and queried lazily the first time
+// a script runs "plugin <name>".
+//
+// The returned cleanup function must be called when the whole test run has
+// finished; it shuts down any plugin processes that were started. Because
+// [testscript.Run] runs scripts as parallel subtests that execute after the
+// calling test function returns, the cleanup function must be registered with
+// t.Cleanup rather than deferred: a deferred call would run before the scripts
+// (and the plugin processes they start) had finished, leaving processes alive.
+func Setup(p *testscript.Params) (cleanup func(), err error) {
+	ps := &plugins{
+		started: make(map[string]*startedPlugin),
+	}
+	if p.Cmds == nil {
+		p.Cmds = make(map[string]func(ts *testscript.TestScript, neg bool, args []string))
+	}
+	p.Cmds["plugin"] = ps.cmdPlugin
+	return ps.close, nil
+}
+
+type plugins struct {
+	// mu guards the fields below it.
+	mu      sync.Mutex
+	started map[string]*startedPlugin
+}
+
+type startedPlugin struct {
+	client Interface
+	info   PluginInfo
+	proc   *procConn
+}
+
+func (ps *plugins) close() {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	for _, sp := range ps.started {
+		sp.client.Close()
+	}
+	ps.started = make(map[string]*startedPlugin)
+}
+
+// get returns the started plugin with the given name, starting it on first
+// use.
+func (ps *plugins) get(name string) (*startedPlugin, error) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	if sp := ps.started[name]; sp != nil {
+		return sp, nil
+	}
+	exe := "testscript-plugin-" + name
+	path, err := exec.LookPath(exe)
+	if err != nil {
+		return nil, fmt.Errorf("cannot find plugin executable %q: %v", exe, err)
+	}
+	conn, err := startProcess(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot start plugin %q: %v", name, err)
+	}
+	client, err := NewClient(conn)
+	if err != nil {
+		return nil, fmt.Errorf("cannot start plugin %q: %v", name, err)
+	}
+	sp := &startedPlugin{
+		client: client,
+		info:   client.Info(),
+		proc:   conn,
+	}
+	ps.started[name] = sp
+	return sp, nil
+}
+
+// startProcess starts the plugin executable at path and returns a connection
+// to it: data written to the connection goes to the process's standard input,
+// data read comes from its standard output, and its standard error is captured
+// so it can be reported through the log of whichever test is interacting with
+// the plugin. Closing the connection shuts the process down.
+func startProcess(path string) (*procConn, error) {
+	cmd := exec.Command(path)
+	w, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	r, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stderr := new(lockedBuffer)
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return &procConn{cmd: cmd, r: r, w: w, stderr: stderr}, nil
+}
+
+// procConn is the connection to a plugin subprocess, presenting its
+// stdin/stdout as an [io.ReadWriteCloser].
+type procConn struct {
+	cmd    *exec.Cmd
+	r      io.ReadCloser
+	w      io.WriteCloser
+	stderr *lockedBuffer
+}
+
+func (p *procConn) Read(b []byte) (int, error)  { return p.r.Read(b) }
+func (p *procConn) Write(b []byte) (int, error) { return p.w.Write(b) }
+
+// Close shuts the process down: closing its standard input signals the plugin
+// server loop to exit; if it does not exit promptly it is killed.
+func (p *procConn) Close() error {
+	p.w.Close()
+	done := make(chan struct{})
+	go func() {
+		p.cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		p.cmd.Process.Kill()
+		<-done
+	}
+	p.r.Close()
+	// The process has exited, so its standard error is fully captured. Any
+	// output not already reported through a test's log (for example a crash
+	// during shutdown, which belongs to no test) is written to the host's
+	// standard error as a last resort so it is not lost.
+	if out := p.stderr.drain(); out != "" {
+		fmt.Fprintf(os.Stderr, "plugin stderr: %s", out)
+	}
+	return nil
+}
+
+// cmdPlugin implements the "plugin <name> [<dir>]" command. It creates a
+// per-test instance of the named plugin, applies the environment variables it
+// provides, and registers the commands it provides for the current test.
+func (ps *plugins) cmdPlugin(ts *testscript.TestScript, neg bool, args []string) {
+	if neg {
+		ts.Fatalf("plugin command does not support negation")
+	}
+	if len(args) < 1 || len(args) > 2 {
+		ts.Fatalf("usage: plugin <name> [<dir>]")
+	}
+	name := args[0]
+	sp, err := ps.get(name)
+	if err != nil {
+		ts.Fatalf("%v", err)
+	}
+
+	env := resolveEnv(ts, sp.info.RequiredEnv)
+	dir := ""
+	if len(args) > 1 {
+		dir = ts.MkAbs(args[1])
+	}
+	inst, err := sp.client.NewTestInstance(TestParams{
+		TestName:        ts.Name(),
+		PluginParamsDir: dir,
+		Env:             env,
+	})
+	logPluginStderr(ts, name, sp)
+	if err != nil {
+		ts.Fatalf("cannot create instance of plugin %q: %v", name, err)
+	}
+	ts.Defer(inst.Close)
+
+	ps.applyEnv(ts, name, sp.info, inst.Env())
+	for cmdName := range sp.info.Cmds {
+		ts.SetCmd(cmdName, ps.makeCmd(name, sp, cmdName, inst))
+	}
+}
+
+// makeCmd returns the testscript command implementation for a command
+// provided by a plugin.
+func (ps *plugins) makeCmd(name string, sp *startedPlugin, cmdName string, inst TestInstance) func(*testscript.TestScript, bool, []string) {
+	cmdInfo := sp.info.Cmds[cmdName]
+	return func(ts *testscript.TestScript, neg bool, args []string) {
+		env := resolveEnv(ts, cmdInfo.RequiredEnv)
+		res, err := inst.RunCmd(CmdParams{
+			Name: cmdName,
+			Args: args,
+			Dir:  ts.MkAbs("."),
+			Env:  env,
+		})
+		logPluginStderr(ts, name, sp)
+		if err != nil {
+			// A plugin/transport failure is fatal regardless of negation.
+			ts.Fatalf("plugin %q failed to run command %q: %v", name, cmdName, err)
+		}
+		if cmdInfo.WritesOutput {
+			ts.Stdout().Write(res.Stdout)
+			ts.Stderr().Write(res.Stderr)
+		}
+		ps.applyEnv(ts, name, sp.info, res.Env)
+
+		if res.Err != "" {
+			ts.Logf("[%v]\n", res.Err)
+			if !neg {
+				ts.Fatalf("unexpected command failure")
+			}
+		} else if neg {
+			ts.Fatalf("unexpected command success")
+		}
+	}
+}
+
+// applyEnv sets the environment variables provided by a plugin, rejecting any
+// that the plugin did not declare in its ResultEnv.
+func (ps *plugins) applyEnv(ts *testscript.TestScript, name string, info PluginInfo, env map[string]string) {
+	for k, v := range env {
+		if !info.ResultEnv[k] {
+			ts.Fatalf("plugin %q tried to set undeclared environment variable %q", name, k)
+		}
+		ts.Setenv(k, v)
+	}
+}
+
+// resolveEnv returns the values of the requested environment variables in the
+// test environment.
+func resolveEnv(ts *testscript.TestScript, required map[string]bool) map[string]string {
+	env := make(map[string]string)
+	for varName := range required {
+		env[varName] = ts.Getenv(varName)
+	}
+	return env
+}
+
+// logPluginStderr reports any output the plugin process has written to its
+// standard error since the last call, attributing it to the given test's log.
+// Because a single plugin process is shared by all tests using it, this is
+// best-effort: output is surfaced through whichever test next interacts with
+// the plugin, but it keeps the output within the test framework rather than
+// letting it interleave on the host's standard error.
+func logPluginStderr(ts *testscript.TestScript, name string, sp *startedPlugin) {
+	if out := sp.proc.stderr.drain(); out != "" {
+		ts.Logf("plugin %q stderr: %s", name, out)
+	}
+}
+
+// lockedBuffer is an [io.Writer], safe for concurrent use, that accumulates
+// writes until drained. It captures a plugin process's standard error so it
+// can be reported through a test's log.
+//
+// mu guards the fields below it.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+// drain returns any data accumulated since the last call and resets the buffer.
+func (b *lockedBuffer) drain() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	s := b.buf.String()
+	b.buf.Reset()
+	return s
+}

--- a/testscript/plugin/plugin_test.go
+++ b/testscript/plugin/plugin_test.go
@@ -1,0 +1,162 @@
+package plugin_test
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/rogpeppe/go-internal/testscript"
+	"github.com/rogpeppe/go-internal/testscript/plugin"
+)
+
+func TestMain(m *testing.M) {
+	// Register the test plugins as commands so that testscript.Main makes
+	// them available on $PATH under their "testscript-plugin-<name>" names,
+	// which is how the plugin host discovers them.
+	testscript.Main(m, map[string]func(){
+		"testscript-plugin-demo": func() {
+			if err := plugin.Serve(demoPlugin{}); err != nil {
+				log.Fatal(err)
+			}
+		},
+		"testscript-plugin-kv": func() {
+			if err := plugin.Serve(kvPlugin{}); err != nil {
+				log.Fatal(err)
+			}
+		},
+	})
+}
+
+func TestPlugin(t *testing.T) {
+	p := testscript.Params{
+		Dir: "testdata",
+	}
+	cleanup, err := plugin.Setup(&p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
+	testscript.Run(t, p)
+}
+
+// demoPlugin exercises most of the plugin contract: it reads its parameter
+// directory and a variable from the test environment when an instance is
+// created, exposes result variables, and provides commands that produce
+// standard output and standard error, run in the script's working directory,
+// set environment variables, and fail.
+type demoPlugin struct{}
+
+func (demoPlugin) Info() plugin.PluginInfo {
+	return plugin.PluginInfo{
+		RequiredEnv: map[string]bool{"GREETING": true},
+		ResultEnv:   map[string]bool{"DEMO_MESSAGE": true, "DEMO_TOKEN": true},
+		Cmds: map[string]plugin.CmdInfo{
+			"echo":     {WritesOutput: true},
+			"warn":     {WritesOutput: true},
+			"cwd":      {WritesOutput: true},
+			"settoken": {},
+			"fail":     {WritesOutput: true},
+		},
+	}
+}
+
+func (demoPlugin) NewTestInstance(p plugin.TestParams) (plugin.TestInstance, error) {
+	name := "anonymous"
+	if p.PluginParamsDir != "" {
+		data, err := os.ReadFile(filepath.Join(p.PluginParamsDir, "name.txt"))
+		if err != nil {
+			return nil, fmt.Errorf("cannot read plugin parameter directory: %v", err)
+		}
+		name = strings.TrimSpace(string(data))
+	}
+	greeting := p.Env["GREETING"]
+	if greeting == "" {
+		greeting = "hello"
+	}
+	return &demoInstance{message: greeting + ", " + name}, nil
+}
+
+func (demoPlugin) Close() {}
+
+type demoInstance struct {
+	message string
+}
+
+func (inst *demoInstance) Env() map[string]string {
+	return map[string]string{"DEMO_MESSAGE": inst.message}
+}
+
+func (inst *demoInstance) RunCmd(p plugin.CmdParams) (plugin.CmdResult, error) {
+	switch p.Name {
+	case "echo":
+		return plugin.CmdResult{Stdout: []byte(strings.Join(p.Args, " ") + "\n")}, nil
+	case "warn":
+		return plugin.CmdResult{Stderr: []byte(strings.Join(p.Args, " ") + "\n")}, nil
+	case "cwd":
+		return plugin.CmdResult{Stdout: []byte(p.Dir + "\n")}, nil
+	case "settoken":
+		if len(p.Args) != 1 {
+			return plugin.CmdResult{}, fmt.Errorf("usage: settoken <value>")
+		}
+		return plugin.CmdResult{Env: map[string]string{"DEMO_TOKEN": p.Args[0]}}, nil
+	case "fail":
+		return plugin.CmdResult{Stderr: []byte("deliberate failure\n"), Err: "exit status 1"}, nil
+	}
+	return plugin.CmdResult{}, fmt.Errorf("unrecognized command %q", p.Name)
+}
+
+func (inst *demoInstance) Close() {}
+
+// kvPlugin is a minimal plugin invoked without a parameter directory. Each test
+// instance holds its own in-memory key-value store, demonstrating that an
+// instance persists state across the commands of a single test (the classic
+// "scratch server" use case).
+type kvPlugin struct{}
+
+func (kvPlugin) Info() plugin.PluginInfo {
+	return plugin.PluginInfo{
+		Cmds: map[string]plugin.CmdInfo{
+			"set": {},
+			"get": {WritesOutput: true},
+		},
+	}
+}
+
+func (kvPlugin) NewTestInstance(p plugin.TestParams) (plugin.TestInstance, error) {
+	return &kvInstance{store: make(map[string]string)}, nil
+}
+
+func (kvPlugin) Close() {}
+
+type kvInstance struct {
+	// mu guards the fields below it.
+	mu    sync.Mutex
+	store map[string]string
+}
+
+func (inst *kvInstance) Env() map[string]string { return nil }
+
+func (inst *kvInstance) RunCmd(p plugin.CmdParams) (plugin.CmdResult, error) {
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+	switch p.Name {
+	case "set":
+		if len(p.Args) != 2 {
+			return plugin.CmdResult{}, fmt.Errorf("usage: set <key> <value>")
+		}
+		inst.store[p.Args[0]] = p.Args[1]
+		return plugin.CmdResult{}, nil
+	case "get":
+		if len(p.Args) != 1 {
+			return plugin.CmdResult{}, fmt.Errorf("usage: get <key>")
+		}
+		return plugin.CmdResult{Stdout: []byte(inst.store[p.Args[0]] + "\n")}, nil
+	}
+	return plugin.CmdResult{}, fmt.Errorf("unrecognized command %q", p.Name)
+}
+
+func (inst *kvInstance) Close() {}

--- a/testscript/plugin/protocol.go
+++ b/testscript/plugin/protocol.go
@@ -1,0 +1,72 @@
+package plugin
+
+import "encoding/json"
+
+// This file defines the JSON-RPC wire format used between [NewClient] and
+// [NewServer]. These types are private implementation details of the plugin
+// transport; the protocol can be documented separately if a non-Go plugin
+// implementation is ever needed.
+//
+// A request is a JSON object {"id","method","params"}; a response is a JSON
+// object {"id","result","error"}. Requests and responses are concatenated
+// JSON values on the connection. Each request is answered by exactly one
+// response with the same id; a non-empty error reports a failure of the
+// invoked method.
+
+const (
+	methodInfo          = "Info"
+	methodNewInstance   = "NewInstance"
+	methodRunCmd        = "RunCmd"
+	methodCloseInstance = "CloseInstance"
+)
+
+// protocolVersion is the version of the wire protocol implemented by this
+// package. The client sends the highest version it supports in the Info
+// request; the server replies with the version it has selected, which is never
+// greater than the version the client sent. Currently both are always 1, but
+// the exchange lets future versions negotiate protocol changes. The version is
+// an internal detail of the transport and is not exposed in the Go API.
+const protocolVersion = 1
+
+// infoArgs is the argument to the Info method.
+type infoArgs struct {
+	// Version is the highest protocol version the client supports.
+	Version int
+}
+
+// infoResult is the result of the Info method.
+type infoResult struct {
+	// Version is the protocol version the server has selected. It is never
+	// greater than the version the client sent in infoArgs.
+	Version int
+	Info    PluginInfo
+}
+
+type rpcRequest struct {
+	ID     uint64          `json:"id"`
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	ID     uint64          `json:"id"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  string          `json:"error,omitempty"`
+}
+
+// newInstanceResult is the result of the NewInstance method. Env holds the
+// result of the new instance's Env method, folded into the creation reply to
+// save a round trip.
+type newInstanceResult struct {
+	InstID int
+	Env    map[string]string
+}
+
+type runCmdArgs struct {
+	InstID int
+	Params CmdParams
+}
+
+type closeInstanceArgs struct {
+	InstID int
+}

--- a/testscript/plugin/rpc_test.go
+++ b/testscript/plugin/rpc_test.go
@@ -1,0 +1,219 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakePlugin is a minimal Interface implementation for the round-trip test.
+type fakePlugin struct {
+	mu     sync.Mutex
+	closed bool
+}
+
+func (p *fakePlugin) Info() PluginInfo {
+	return PluginInfo{
+		RequiredEnv: map[string]bool{"WORK": true},
+		ResultEnv:   map[string]bool{"GREETING": true},
+		Cmds:        map[string]CmdInfo{"hello": {WritesOutput: true}},
+	}
+}
+
+func (p *fakePlugin) NewTestInstance(tp TestParams) (TestInstance, error) {
+	if tp.TestName == "fail" {
+		return nil, fmt.Errorf("instance creation refused")
+	}
+	return &fakeInstance{work: tp.Env["WORK"]}, nil
+}
+
+func (p *fakePlugin) Close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closed = true
+}
+
+type fakeInstance struct {
+	work string
+}
+
+func (i *fakeInstance) Env() map[string]string {
+	return map[string]string{"GREETING": "hi from " + i.work}
+}
+
+func (i *fakeInstance) RunCmd(p CmdParams) (CmdResult, error) {
+	switch p.Name {
+	case "hello":
+		return CmdResult{Stdout: []byte("hello " + p.Args[0] + "\n")}, nil
+	case "boom":
+		return CmdResult{}, fmt.Errorf("plugin transport boom")
+	case "fail":
+		return CmdResult{Stderr: []byte("oops\n"), Err: "exit status 1"}, nil
+	}
+	return CmdResult{}, fmt.Errorf("unknown command %q", p.Name)
+}
+
+func (i *fakeInstance) Close() {}
+
+// rwc is an io.ReadWriteCloser built from a separate reader and writer, used
+// to connect an in-process client and server over pipes.
+type rwc struct {
+	r io.ReadCloser
+	w io.WriteCloser
+}
+
+func (c rwc) Read(b []byte) (int, error)  { return c.r.Read(b) }
+func (c rwc) Write(b []byte) (int, error) { return c.w.Write(b) }
+func (c rwc) Close() error {
+	c.r.Close()
+	c.w.Close()
+	return nil
+}
+
+// startInProcess runs a [NewServer] loop connected to an in-process [NewClient]
+// via two pipes, returning the client and a cleanup function.
+func startInProcess(t *testing.T, impl Interface) (Interface, func()) {
+	t.Helper()
+	// client writes -> server reads
+	cr, cw := io.Pipe()
+	// server writes -> client reads
+	sr, sw := io.Pipe()
+
+	serveDone := make(chan struct{})
+	go func() {
+		NewServer(impl, rwc{r: cr, w: sw})
+		close(serveDone)
+	}()
+
+	c, err := NewClient(rwc{r: sr, w: cw})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	cleanup := func() {
+		c.Close()
+		<-serveDone
+	}
+	return c, cleanup
+}
+
+func TestRoundTrip(t *testing.T) {
+	impl := &fakePlugin{}
+	c, cleanup := startInProcess(t, impl)
+	defer cleanup()
+
+	if cmds := c.Info().Cmds; len(cmds) != 1 || !cmds["hello"].WritesOutput {
+		t.Fatalf("unexpected Info().Cmds: %v", cmds)
+	}
+
+	inst, err := c.NewTestInstance(TestParams{
+		TestName: "t1",
+		Env:      map[string]string{"WORK": "/tmp/work"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := inst.Env()["GREETING"], "hi from /tmp/work"; got != want {
+		t.Errorf("Env()[GREETING] = %q, want %q", got, want)
+	}
+
+	res, err := inst.RunCmd(CmdParams{Name: "hello", Args: []string{"world"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(res.Stdout), "hello world\n"; got != want {
+		t.Errorf("stdout = %q, want %q", got, want)
+	}
+
+	// A command failure is reported via CmdResult.Err, not the Go error.
+	res, err = inst.RunCmd(CmdParams{Name: "fail"})
+	if err != nil {
+		t.Fatalf("unexpected transport error for command failure: %v", err)
+	}
+	if res.Err != "exit status 1" {
+		t.Errorf("res.Err = %q, want %q", res.Err, "exit status 1")
+	}
+	if got := string(res.Stderr); got != "oops\n" {
+		t.Errorf("stderr = %q, want %q", got, "oops\n")
+	}
+
+	// A plugin (transport-level) failure is reported via the Go error.
+	if _, err := inst.RunCmd(CmdParams{Name: "boom"}); err == nil || !strings.Contains(err.Error(), "plugin transport boom") {
+		t.Errorf("RunCmd(boom) err = %v, want one containing %q", err, "plugin transport boom")
+	}
+
+	inst.Close()
+}
+
+// TestProtocolVersionTooNew checks that the client rejects a server that
+// selects a protocol version newer than the client sent.
+func TestProtocolVersionTooNew(t *testing.T) {
+	// client writes -> server reads
+	cr, cw := io.Pipe()
+	// server writes -> client reads
+	sr, sw := io.Pipe()
+
+	// A hand-rolled server that answers the Info handshake with a version
+	// greater than the one requested.
+	go func() {
+		dec := json.NewDecoder(cr)
+		enc := json.NewEncoder(sw)
+		var req rpcRequest
+		if err := dec.Decode(&req); err != nil {
+			return
+		}
+		enc.Encode(rpcResponse{
+			ID:     req.ID,
+			Result: mustMarshal(infoResult{Version: protocolVersion + 1}),
+		})
+	}()
+
+	_, err := NewClient(rwc{r: sr, w: cw})
+	if err == nil || !strings.Contains(err.Error(), "protocol version") {
+		t.Fatalf("NewClient err = %v, want one mentioning protocol version", err)
+	}
+}
+
+func TestNewInstanceError(t *testing.T) {
+	c, cleanup := startInProcess(t, &fakePlugin{})
+	defer cleanup()
+
+	if _, err := c.NewTestInstance(TestParams{TestName: "fail"}); err == nil || !strings.Contains(err.Error(), "instance creation refused") {
+		t.Errorf("NewTestInstance err = %v, want one containing %q", err, "instance creation refused")
+	}
+}
+
+func TestConcurrentInstances(t *testing.T) {
+	c, cleanup := startInProcess(t, &fakePlugin{})
+	defer cleanup()
+
+	const n = 20
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			inst, err := c.NewTestInstance(TestParams{
+				TestName: fmt.Sprintf("t%d", i),
+				Env:      map[string]string{"WORK": fmt.Sprintf("/w%d", i)},
+			})
+			if err != nil {
+				t.Errorf("NewTestInstance: %v", err)
+				return
+			}
+			defer inst.Close()
+			res, err := inst.RunCmd(CmdParams{Name: "hello", Args: []string{fmt.Sprintf("%d", i)}})
+			if err != nil {
+				t.Errorf("RunCmd: %v", err)
+				return
+			}
+			if got, want := string(res.Stdout), fmt.Sprintf("hello %d\n", i); got != want {
+				t.Errorf("stdout = %q, want %q", got, want)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/testscript/plugin/server.go
+++ b/testscript/plugin/server.go
@@ -1,0 +1,145 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+)
+
+// Serve runs a plugin server for impl, reading JSON-RPC requests from
+// [os.Stdin] and writing responses to [os.Stdout]. It is a convenience wrapper
+// around [NewServer]; a plugin binary's main is typically just a call to Serve.
+//
+// A plugin must not write anything other than JSON-RPC frames to standard
+// output. Use standard error (the default for the log package) for logging.
+func Serve(impl Interface) error {
+	return NewServer(impl, struct {
+		io.Reader
+		io.Writer
+	}{os.Stdin, os.Stdout})
+}
+
+// NewServer reads JSON-RPC requests from c and writes responses to c, invoking
+// the corresponding methods of impl. It is the counterpart of [NewClient]. It
+// returns when it reads EOF from c (which the host arranges by closing the
+// connection when it shuts the plugin down), after calling impl.Close.
+//
+// Requests are dispatched concurrently, so impl's methods must be safe for
+// concurrent use.
+func NewServer(impl Interface, c io.ReadWriter) error {
+	s := &server{impl: impl, insts: make(map[int]TestInstance)}
+	dec := json.NewDecoder(c)
+	enc := json.NewEncoder(c)
+	var (
+		wg    sync.WaitGroup
+		encMu sync.Mutex
+	)
+	var loopErr error
+	for {
+		var req rpcRequest
+		if err := dec.Decode(&req); err != nil {
+			if err != io.EOF {
+				loopErr = err
+			}
+			break
+		}
+		wg.Add(1)
+		go func(req rpcRequest) {
+			defer wg.Done()
+			result, errStr := s.dispatch(req.Method, req.Params)
+			encMu.Lock()
+			enc.Encode(rpcResponse{ID: req.ID, Result: result, Error: errStr})
+			encMu.Unlock()
+		}(req)
+	}
+	wg.Wait()
+	impl.Close()
+	return loopErr
+}
+
+// server tracks the test instances created on behalf of a single connection.
+type server struct {
+	impl Interface
+
+	// mu guards the fields below it. Per-instance work runs without the lock
+	// held so that commands on different instances proceed in parallel.
+	mu    sync.Mutex
+	next  int
+	insts map[int]TestInstance
+}
+
+// dispatch invokes the named method and returns its JSON-encoded result, or a
+// non-empty error string if the method failed.
+func (s *server) dispatch(method string, params json.RawMessage) (json.RawMessage, string) {
+	switch method {
+	case methodInfo:
+		var a infoArgs
+		if len(params) > 0 {
+			if err := json.Unmarshal(params, &a); err != nil {
+				return nil, err.Error()
+			}
+		}
+		// Select the lower of the version we implement and the version the
+		// client asked for, so the reply is never newer than the client
+		// understands.
+		version := min(protocolVersion, a.Version)
+		return mustMarshal(infoResult{Version: version, Info: s.impl.Info()}), ""
+	case methodNewInstance:
+		var p TestParams
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, err.Error()
+		}
+		inst, err := s.impl.NewTestInstance(p)
+		if err != nil {
+			return nil, err.Error()
+		}
+		s.mu.Lock()
+		s.next++
+		id := s.next
+		s.insts[id] = inst
+		s.mu.Unlock()
+		return mustMarshal(newInstanceResult{InstID: id, Env: inst.Env()}), ""
+	case methodRunCmd:
+		var a runCmdArgs
+		if err := json.Unmarshal(params, &a); err != nil {
+			return nil, err.Error()
+		}
+		s.mu.Lock()
+		inst := s.insts[a.InstID]
+		s.mu.Unlock()
+		if inst == nil {
+			return nil, fmt.Sprintf("unknown plugin instance %d", a.InstID)
+		}
+		res, err := inst.RunCmd(a.Params)
+		if err != nil {
+			return nil, err.Error()
+		}
+		return mustMarshal(res), ""
+	case methodCloseInstance:
+		var a closeInstanceArgs
+		if err := json.Unmarshal(params, &a); err != nil {
+			return nil, err.Error()
+		}
+		s.mu.Lock()
+		inst := s.insts[a.InstID]
+		delete(s.insts, a.InstID)
+		s.mu.Unlock()
+		if inst != nil {
+			inst.Close()
+		}
+		return nil, ""
+	}
+	return nil, fmt.Sprintf("unknown method %q", method)
+}
+
+func mustMarshal(v any) json.RawMessage {
+	data, err := json.Marshal(v)
+	if err != nil {
+		// The values marshaled here are simple data structures that should
+		// always marshal successfully.
+		panic(err)
+	}
+	return data
+}

--- a/testscript/plugin/testdata/demo.txtar
+++ b/testscript/plugin/testdata/demo.txtar
@@ -1,0 +1,49 @@
+# The demo plugin reads its parameter directory and the GREETING variable from
+# the test environment when its instance is created, then exposes a result
+# variable built from both. The commands it provides ("echo", "warn", ...)
+# become available directly after the "plugin" command runs.
+env GREETING=howdy
+plugin demo params
+
+# The variable provided by the plugin instance (via Env) is set in the script
+# environment.
+echo $DEMO_MESSAGE
+stdout '^howdy, world$'
+
+# A command writes to standard output.
+echo one two three
+stdout '^one two three$'
+
+# A command writes to standard error.
+warn something is wrong
+stderr '^something is wrong$'
+
+# A command runs in the script's current working directory.
+cd sub
+cwd
+stdout '[/\\]sub$'
+cd ..
+
+# A command can set an environment variable mid-script (via CmdResult.Environ).
+settoken sesame
+echo $DEMO_TOKEN
+stdout '^sesame$'
+
+# A failing command is reported as a failure, can be negated, and its output
+# is still captured.
+! fail
+stderr '^deliberate failure$'
+
+# A second plugin can be used alongside the first. The kv plugin is invoked
+# without a parameter directory, and its instance keeps state across commands.
+plugin kv
+set color blue
+get color
+stdout '^blue$'
+get missing
+stdout '^$'
+
+-- params/name.txt --
+world
+-- sub/keep.txt --
+placeholder


### PR DESCRIPTION
This adds the capability for a testscript script to use a "plugin", an external binary that implements support for additional functionality not easily implemented with a regular command. Except when using the testscript command, it must be explicitly enabled by using `plugin.Setup`.

A plugin binary is run as an RPC server communicating over stdin/stdout, and can provide extra commands and environment variables to a testscript test. A classic use case is to run a scratch server, set an environment variable referring to its address, and tear it down when a test is done.

For now we use a custom RPC implementation so we can avoid polluting the Go API (unfortunately `net/rpc` requires that the types used are made public).

When `plugin` is invoked inside a testscript, e.g.

```
plugin foo
```

a plugin binary is searched for with the name `testscript-plugin-foo`.

For reference, we implement the existing Go proxy support as a plugin. In the future we may decide to fully factor out this support from the core testscript executable, although we'll have to be careful about backward compatibility concerns.